### PR TITLE
Add local version of the [Colab notebook](  https://github.com/tensor…

### DIFF
--- a/tensorboard_profiling_keras.py
+++ b/tensorboard_profiling_keras.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+#@title Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import os
+import tensorflow as tf
+
+print("TensorFlow version: ", tf.__version__)
+
+device_name = tf.test.gpu_device_name()
+if not device_name:
+  raise SystemError('GPU device not found')
+print('Found GPU at: {}'.format(device_name))
+
+import tensorflow_datasets as tfds
+tfds.disable_progress_bar()
+
+
+# Limit to a short training time tfor demonstration purposes
+Epochs = 2
+
+
+(ds_train, ds_test), ds_info = tfds.load(
+    'mnist',
+    split=['train', 'test'],
+    shuffle_files=True,
+    as_supervised=True,
+    with_info=True,
+)
+
+def normalize_img(image, label):
+  """Normalizes images: `uint8` -> `float32`."""
+  return tf.cast(image, tf.float32) / 255., label
+
+ds_train = ds_train.map(normalize_img)
+ds_train = ds_train.batch(128)
+
+ds_test = ds_test.map(normalize_img)
+ds_test = ds_test.batch(128)
+
+model = tf.keras.models.Sequential([
+  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+  tf.keras.layers.Dense(128,activation='relu'),
+  tf.keras.layers.Dense(10, activation='softmax')
+])
+model.compile(
+    loss='sparse_categorical_crossentropy',
+    optimizer=tf.keras.optimizers.Adam(0.001),
+    metrics=['accuracy']
+)
+
+# Create a TensorBoard callback
+logs = "logs/" + datetime.now().strftime("%Y%m%d-%H%M%S")
+
+tboard_callback = tf.keras.callbacks.TensorBoard(log_dir = logs,
+                                                 histogram_freq = 1,
+                                                 profile_batch = (1, Epochs)) # Note: 1-indexed
+
+model.fit(ds_train,
+          epochs=Epochs,
+          validation_data=ds_test,
+          callbacks = [tboard_callback])
+
+
+(ds_train, ds_test), ds_info = tfds.load(
+    'mnist',
+    split=['train', 'test'],
+    shuffle_files=True,
+    as_supervised=True,
+    with_info=True,
+)
+
+ds_train = ds_train.map(normalize_img)
+ds_train = ds_train.batch(128)
+ds_train = ds_train.cache()
+ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)
+
+ds_test = ds_test.map(normalize_img)
+ds_test = ds_test.batch(128)
+ds_test = ds_test.cache()
+ds_test = ds_test.prefetch(tf.data.experimental.AUTOTUNE)
+
+model.fit(ds_train,
+          epochs=Epochs,
+          validation_data=ds_test,
+          callbacks = [tboard_callback])
+
+


### PR DESCRIPTION
It seems that a number of users are having problems running the profiler on their own setups.
Currently, the main source of documentation is a colaboratory notebook - which is therefore limited to Google environments, and has specific packages and jupyter magic set up. And is currently broken, not displaying any data or even the profile tab. The installa and run script only verifies that tensorboard launches - it does not . It is also not suitable ofr users not using `virtualenv` for their package management (I have installed the tensorflow packages through a mamba environment and conda-forge).

This commit adds a script that is currently just a copy of the notebook in a vanilla python. With one change that the number of epochs is matched to the setup in the trianing loop (as otherwise no data are collected). 

However, as a starting point, I think it ought to be expanded out to include further test cases and any edits made as appropriate to produce the sort of data that is in the /data folder of the repository.

In my case for example, I can open up the data and tensorboard and the profiler correctly display it. But I am getting generic errors that data were not captured for the timesteps involved if I then try to generate my own data. It is not clear what the issue is here, as I have resolved any problems relating to warnings output (and if this script can detect some of those programmatically, then that would be great - e.g. not being able to find the cuda PTI libraries).

Hopefully if a script like this can be expanded, then that would help both users and maintainers with diagnosing issues, especially as it seems the whole TF ecosystem is changing in a way that is breaking links. I think a full reproducible example all the way through from verifying setup through to data generation and then visualisation, that works with GPUs and a user's current installation environment, would be a good thing to add.

Relevant issues: !578 !835 !653 !839 !613


===============================



Add local version of the [Colab notebook](  https://github.com/tensorflow/tensorboard/blob/master/docs/tensorboard_profiling_keras.ipynb  ) as a starting point for more reproducible testing for a local installation. This file ideally should be fleshed out to include more tests as part of installation and to ensure that data are being gathered correctly.