### PR TITLE
[DOCS] Update docker build command

### DIFF
--- a/docs/docker_deployment.md
+++ b/docs/docker_deployment.md
@@ -35,7 +35,7 @@ CMD ["--logdir=/app/logs", "--port=8791"]
 2.  Build the image using the following command:
 
     ```bash
-    docker build -t xprof:2.21.0 .
+    docker build --platform=linux/amd64 -t xprof:2.21.0 .
     ```
 
 You can change the version by modifying the `XPROF_VERSION` argument in the


### PR DESCRIPTION
Specify `platform=linux/amd64`

## Details

With the original command, I saw the following error:

```shell
 => ERROR [3/3] RUN pip install --no-cache-dir xprof==2.21.0                                                                  1.2s
------                                                                                                                             
 > [3/3] RUN pip install --no-cache-dir xprof==2.21.0:                                                                             
1.038 ERROR: Ignored the following yanked versions: 2.20.3                                                                         
1.038 ERROR: Could not find a version that satisfies the requirement xprof==2.21.0 (from versions: 2.19.6, 2.19.7, 2.19.8, 2.19.9, 2.20.0, 2.20.2a0, 2.20.2, 2.20.4, 2.20.5, 2.20.6, 2.20.7)                                                                          
1.038 ERROR: No matching distribution found for xprof==2.21.0
1.169 
1.169 [notice] A new release of pip is available: 24.0 -> 25.3
1.169 [notice] To update, run: pip install --upgrade pip
------
Dockerfile:9
--------------------
   7 |     WORKDIR /app
   8 |     
   9 | >>> RUN pip install --no-cache-dir xprof==${XPROF_VERSION}
  10 |     
  11 |     EXPOSE 8791 50051
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pip install --no-cache-dir xprof==${XPROF_VERSION}" did not complete successfully: exit code: 1
```

And, on inspection, this was because by default this was using manylinux-aarch64, but the wheels on pypi are only built for manylinux-x86_64.

The docker build works as expected with the platform option, hence this update.