### PR TITLE
Migrate to the Sass module system

### DIFF
--- a/frontend/app/components/capture_profile/capture_profile.scss
+++ b/frontend/app/components/capture_profile/capture_profile.scss
@@ -1,6 +1,6 @@
 /** CSS for a capture profile view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-spinner {
   position: absolute;
@@ -9,6 +9,6 @@ mat-spinner {
 }
 
 .mat-mdc-raised-button {
-  @include box-shadow-none;
-  @include border-black;
+  @include common.box-shadow-none;
+  @include common.border-black;
 }

--- a/frontend/app/components/capture_profile/capture_profile_dialog/capture_profile_dialog.scss
+++ b/frontend/app/components/capture_profile/capture_profile_dialog/capture_profile_dialog.scss
@@ -1,6 +1,6 @@
 /** CSS for a capture profile dialog component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-expansion-panel {
   width: 400px;
@@ -23,6 +23,6 @@ mat-dialog-actions {
 }
 
 .mat-mdc-raised-button {
-  @include box-shadow-none;
-  @include border-black;
+  @include common.box-shadow-none;
+  @include common.border-black;
 }

--- a/frontend/app/components/controls/category_filter/category_filter.scss
+++ b/frontend/app/components/controls/category_filter/category_filter.scss
@@ -1,6 +1,6 @@
 /** CSS for category filter component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/controls/download_hlo/download_hlo.scss
+++ b/frontend/app/components/controls/download_hlo/download_hlo.scss
@@ -1,12 +1,12 @@
 /** CSS for a download hlo component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .save-button {
   text-align: center;
 }
 
 .save-button:hover {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   cursor: pointer;
 }

--- a/frontend/app/components/controls/export_as_csv/export_as_csv.scss
+++ b/frontend/app/components/controls/export_as_csv/export_as_csv.scss
@@ -1,6 +1,6 @@
 /** CSS for export-as-CSV component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .save-button {
   padding-top: 8px;
@@ -9,6 +9,6 @@
 }
 
 .save-button:hover {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   cursor: pointer;
 }

--- a/frontend/app/components/controls/string_filter/string_filter.scss
+++ b/frontend/app/components/controls/string_filter/string_filter.scss
@@ -1,13 +1,13 @@
 /** CSS for string filter component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
 }
 
 mat-icon {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   vertical-align: bottom;
 }
 

--- a/frontend/app/components/controls/view_architecture/view_architecture.scss
+++ b/frontend/app/components/controls/view_architecture/view_architecture.scss
@@ -1,6 +1,6 @@
 /** CSS for export-as-CSV component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .save-button {
   padding-top: 8px;
@@ -9,6 +9,6 @@
 }
 
 .save-button:hover {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   cursor: pointer;
 }

--- a/frontend/app/components/diagnostics_view/diagnostics_view.scss
+++ b/frontend/app/components/diagnostics_view/diagnostics_view.scss
@@ -1,3 +1,3 @@
 /** CSS for a diagnostics view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';

--- a/frontend/app/components/empty_page/empty_page.scss
+++ b/frontend/app/components/empty_page/empty_page.scss
@@ -1,6 +1,6 @@
 /** CSS for an empty page component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/framework_op_stats/framework_op_stats.scss
+++ b/frontend/app/components/framework_op_stats/framework_op_stats.scss
@@ -1,6 +1,6 @@
 /** CSS for a tensorflow stats component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -23,10 +23,10 @@
 }
 
 .mat-mdc-raised-button {
-  @include box-shadow-none;
-  @include border-black;
+  @include common.box-shadow-none;
+  @include common.border-black;
   border-radius: 0;
-  color: $button-focus-color;
+  color: common.$button-focus-color;
 }
 
 model-properties {

--- a/frontend/app/components/framework_op_stats/operations_table/operations_table.scss
+++ b/frontend/app/components/framework_op_stats/operations_table/operations_table.scss
@@ -1,6 +1,6 @@
 /** CSS for an operations table component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -8,6 +8,6 @@
 }
 
 .table {
-  border: 1px solid $border-color;
+  border: 1px solid common.$border-color;
   width: fit-content;
 }

--- a/frontend/app/components/framework_op_stats/stats_table/stats_table.scss
+++ b/frontend/app/components/framework_op_stats/stats_table/stats_table.scss
@@ -1,6 +1,6 @@
 /** CSS for a stats table component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -12,10 +12,10 @@ mat-form-field {
 }
 
 mat-icon {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   vertical-align: bottom;
 }
 
 .table {
-  border: 1px solid $border-color;
+  border: 1px solid common.$border-color;
 }

--- a/frontend/app/components/graph_viewer/graph_viewer.scss
+++ b/frontend/app/components/graph_viewer/graph_viewer.scss
@@ -1,6 +1,6 @@
 /** CSS for a graph viewer component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: flex;

--- a/frontend/app/components/graph_viewer/hlo_text_view/hlo_text_view.scss
+++ b/frontend/app/components/graph_viewer/hlo_text_view/hlo_text_view.scss
@@ -1,6 +1,6 @@
 /** CSS for an hlo-text-view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .hlo-text-area {
   position: relative;

--- a/frontend/app/components/hlo_stats/hlo_stats.scss
+++ b/frontend/app/components/hlo_stats/hlo_stats.scss
@@ -1,6 +1,6 @@
 /** CSS for an hlo stats component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -31,7 +31,7 @@
 }
 
 .table {
-  border: 1px solid $border-color;
+  border: 1px solid common.$border-color;
   margin: 0 16px;
 }
 
@@ -45,6 +45,6 @@
 }
 
 .control-title {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
   margin-bottom: 5px;
 }

--- a/frontend/app/components/inference_profile/inference_profile.scss
+++ b/frontend/app/components/inference_profile/inference_profile.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   padding: 20px;

--- a/frontend/app/components/input_pipeline/analysis_summary/analysis_summary.scss
+++ b/frontend/app/components/input_pipeline/analysis_summary/analysis_summary.scss
@@ -1,6 +1,6 @@
 /** CSS for a summary of input pipeline analysis component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/input_pipeline/device_side_analysis_detail/device_side_analysis_detail.scss
+++ b/frontend/app/components/input_pipeline/device_side_analysis_detail/device_side_analysis_detail.scss
@@ -1,6 +1,6 @@
 /** CSS for a device-side analysis detail view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/input_pipeline/host_op/host_op.scss
+++ b/frontend/app/components/input_pipeline/host_op/host_op.scss
@@ -1,3 +1,3 @@
 /** CSS for a host-op section view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';

--- a/frontend/app/components/input_pipeline/host_side_analysis_detail/host_side_analysis_detail.scss
+++ b/frontend/app/components/input_pipeline/host_side_analysis_detail/host_side_analysis_detail.scss
@@ -1,9 +1,9 @@
 /** CSS for a host-side analysis detail view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-expansion-panel {
-  @include overview-card;
+  @include common.overview-card;
   margin: 0;
 }
 
@@ -12,13 +12,13 @@ mat-expansion-panel-header {
 }
 
 mat-panel-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
   background-color: transparent;
 }
 
 mat-expansion-panel-header.cdk-keyboard-focused,
 mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
-  background-color: $card-title-focus-background-color !important;
+  background-color: common.$card-title-focus-background-color !important;
 }
 
 .mat-expanded mat-expansion-panel-header {
@@ -27,7 +27,7 @@ mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
 }
 
 .section-container {
-  @include border-bottom-gray;
+  @include common.border-bottom-gray;
   padding: 20px;
 }
 
@@ -36,5 +36,5 @@ mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
 }
 
 .column-chart, .recommendations {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
 }

--- a/frontend/app/components/input_pipeline/input_pipeline.scss
+++ b/frontend/app/components/input_pipeline/input_pipeline.scss
@@ -1,6 +1,6 @@
 /** CSS for an input pipeline component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/input_pipeline/max_infeed_detail/max_infeed_detail.scss
+++ b/frontend/app/components/input_pipeline/max_infeed_detail/max_infeed_detail.scss
@@ -1,6 +1,6 @@
 /** CSS for a max-infeed-detail view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .sub-section-title {
   font-size: 22px;

--- a/frontend/app/components/kernel_stats/kernel_stats.scss
+++ b/frontend/app/components/kernel_stats/kernel_stats.scss
@@ -1,6 +1,6 @@
 /** CSS for a kernel stats component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/kernel_stats/kernel_stats_table/kernel_stats_table.scss
+++ b/frontend/app/components/kernel_stats/kernel_stats_table/kernel_stats_table.scss
@@ -1,6 +1,6 @@
 /** CSS for a kernel stats table component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -12,10 +12,10 @@ mat-form-field {
 }
 
 mat-icon {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   vertical-align: bottom;
 }
 
 .table {
-  border: 1px solid $border-color;
+  border: 1px solid common.$border-color;
 }

--- a/frontend/app/components/main_page/main_page.scss
+++ b/frontend/app/components/main_page/main_page.scss
@@ -1,6 +1,6 @@
 /** CSS for a main page component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-sidenav-container {
   background-color: #fff;
@@ -9,7 +9,7 @@ mat-sidenav-container {
 mat-sidenav {
   background: transparent;
   width: 340px;
-  @include border-right-gray
+  @include common.border-right-gray
 }
 
 mat-progress-bar {

--- a/frontend/app/components/megascale_stats/megascale_stats.scss
+++ b/frontend/app/components/megascale_stats/megascale_stats.scss
@@ -1,5 +1,5 @@
 /** CSS for megascale_stats component. */
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .page-container {
   display: flex;

--- a/frontend/app/components/memory_profile/memory_breakdown_table/memory_breakdown_table.scss
+++ b/frontend/app/components/memory_profile/memory_breakdown_table/memory_breakdown_table.scss
@@ -1,6 +1,6 @@
 /** CSS for a memory breakdown table component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -12,7 +12,7 @@ mat-form-field {
 }
 
 mat-icon {
-  color: $button-focus-color;
+  color: common.$button-focus-color;
   vertical-align: bottom;
 }
 

--- a/frontend/app/components/memory_profile/memory_profile.scss
+++ b/frontend/app/components/memory_profile/memory_profile.scss
@@ -1,3 +1,3 @@
 /** CSS for a memory profile component. */
 
-@import 'frontend/app/components/memory_profile/memory_profile_common';
+@use 'frontend/app/components/memory_profile/memory_profile_common';

--- a/frontend/app/components/memory_profile/memory_profile_common.scss
+++ b/frontend/app/components/memory_profile/memory_profile_common.scss
@@ -1,6 +1,6 @@
 /** CSS for a memory profile component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -44,7 +44,7 @@ mat-form-field {
 }
 
 .full-column {
-  @include border-right-gray;
+  @include common.border-right-gray;
   width: 100%;
 }
 

--- a/frontend/app/components/memory_profile/memory_profile_summary/memory_profile_summary.scss
+++ b/frontend/app/components/memory_profile/memory_profile_summary/memory_profile_summary.scss
@@ -1,20 +1,20 @@
 /** CSS for a memory profile summary view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
   flex-grow: 1;
 }
 
 mat-card {
-  @include overview-card;
-  @include overview-card-height;
+  @include common.overview-card;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
   margin-bottom: 25px;
 }
 
@@ -23,7 +23,7 @@ mat-card-title {
 }
 
 ul {
-  @include ul-flat;
+  @include common.ul-flat;
 }
 
 :host ::ng-deep .item-container {

--- a/frontend/app/components/memory_profile/memory_timeline_graph/memory_timeline_graph.scss
+++ b/frontend/app/components/memory_profile/memory_timeline_graph/memory_timeline_graph.scss
@@ -1,20 +1,20 @@
 /** CSS for a memory timeline graph view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
   flex-grow: 1;
 }
 
 mat-card {
-  @include overview-card;
-  @include overview-card-height;
+  @include common.overview-card;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
 }
 
 .chart {

--- a/frontend/app/components/memory_viewer/buffer_details/buffer_details.scss
+++ b/frontend/app/components/memory_viewer/buffer_details/buffer_details.scss
@@ -1,6 +1,6 @@
 /** CSS for a buffer details view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -8,7 +8,7 @@
 }
 
 mat-card {
-  @include detail-card;
+  @include common.detail-card;
 }
 
 .info-header {
@@ -43,12 +43,12 @@ mat-card {
 }
 
 .info-header-subheader {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
   font-style: italic;
 }
 
 .info-content {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
   font-size: 16px;
   padding: 16px;
   word-break: break-word;

--- a/frontend/app/components/memory_viewer/max_heap_chart/max_heap_chart.scss
+++ b/frontend/app/components/memory_viewer/max_heap_chart/max_heap_chart.scss
@@ -1,6 +1,6 @@
 /** CSS for a max heap chart view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/memory_viewer/memory_viewer.scss
+++ b/frontend/app/components/memory_viewer/memory_viewer.scss
@@ -1,6 +1,6 @@
 /** CSS for a memory viewer component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-sidenav-container {
   background-color: #fff;
@@ -9,7 +9,7 @@ mat-sidenav-container {
 mat-sidenav {
   background: transparent;
   width: 340px;
-  @include border-right-gray;
+  @include common.border-right-gray;
 }
 
 mat-progress-bar {

--- a/frontend/app/components/memory_viewer/memory_viewer_control/memory_viewer_control.scss
+++ b/frontend/app/components/memory_viewer/memory_viewer_control/memory_viewer_control.scss
@@ -1,6 +1,6 @@
 /** CSS for a side control component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .item-container {
   padding: 20px 20px 0;

--- a/frontend/app/components/memory_viewer/memory_viewer_main/memory_viewer_main.scss
+++ b/frontend/app/components/memory_viewer/memory_viewer_main/memory_viewer_main.scss
@@ -1,6 +1,6 @@
 /** CSS for a memory viewer main component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -15,7 +15,7 @@
 }
 
 .control-title {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
   margin-bottom: 5px;
 }
 

--- a/frontend/app/components/memory_viewer/program_order_chart/program_order_chart.scss
+++ b/frontend/app/components/memory_viewer/program_order_chart/program_order_chart.scss
@@ -1,6 +1,6 @@
 /** CSS for a program order chart view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/op_profile/op_details/op_details.scss
+++ b/frontend/app/components/op_profile/op_details/op_details.scss
@@ -1,13 +1,13 @@
 /** CSS for an op detail view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
 }
 
 mat-card {
-  @include detail-card;
+  @include common.detail-card;
 }
 
 .info-header {
@@ -42,12 +42,12 @@ mat-card {
 }
 
 .info-header-subheader {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
   font-style: italic;
 }
 
 .info-content {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
   font-size: 16px;
   padding: 16px;
 }

--- a/frontend/app/components/op_profile/op_profile_common.scss
+++ b/frontend/app/components/op_profile/op_profile_common.scss
@@ -1,6 +1,6 @@
 /** Common CSS for an op profile component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 mat-sidenav-container {
   background-color: #fff;
@@ -9,7 +9,7 @@ mat-sidenav-container {
 mat-sidenav {
   background: transparent;
   width: 340px;
-  @include border-right-gray;
+  @include common.border-right-gray;
 }
 
 .container {
@@ -38,12 +38,12 @@ mat-sidenav {
 }
 
 .control-title {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
   margin-bottom: 5px;
 }
 
 .ops-control-title {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
   margin: -20px 0 -24px;
 }
 

--- a/frontend/app/components/op_profile/op_table/op_table.scss
+++ b/frontend/app/components/op_profile/op_table/op_table.scss
@@ -1,6 +1,6 @@
 /** CSS for an op talbe view component. */
 
-@import 'frontend/app/components/op_profile/op_profile_common';
+@use 'frontend/app/components/op_profile/op_profile_common';
 
 .header {
   display: flex;

--- a/frontend/app/components/op_profile/op_table_entry/op_table_entry.scss
+++ b/frontend/app/components/op_profile/op_table_entry/op_table_entry.scss
@@ -1,9 +1,9 @@
 /** CSS for an op talbe entry view component. */
 
-@import 'frontend/app/components/op_profile/op_profile_common';
+@use 'frontend/app/components/op_profile/op_profile_common';
 
 :host {
-  color: $content-primary-color;
+  color: op_profile_common.$content-primary-color;
 }
 
 .row {

--- a/frontend/app/components/overview_page/inference_latency_chart/inference_latency_chart.scss
+++ b/frontend/app/components/overview_page/inference_latency_chart/inference_latency_chart.scss
@@ -1,24 +1,24 @@
 /** CSS for an inference latency chart view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
 }
 
 :host:not(.dark-theme) {
   mat-card {
-    @include overview-card;
+    @include common.overview-card;
   }
 }
 
 mat-card {
-  @include overview-card-height;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
 }
 
 .chart {
@@ -30,12 +30,12 @@ mat-card-title {
   border: none;
 
   mat-card {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-card-title {
-    background-color: $dark-theme-card-title-background-color;
-    color: $dark-theme-card-title-color;
+    background-color: common.$dark-theme-card-title-background-color;
+    color: common.$dark-theme-card-title-color;
     padding: 16px;
     margin: -16px -16px 16px;
   }

--- a/frontend/app/components/overview_page/normalized_accelerator_performance_view/normalized_accelerator_performance_view.scss
+++ b/frontend/app/components/overview_page/normalized_accelerator_performance_view/normalized_accelerator_performance_view.scss
@@ -1,10 +1,10 @@
 /** CSS for a normalized accelerator performance view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host:not(.dark-theme) {
   mat-expansion-panel {
-    @include overview-card;
+    @include common.overview-card;
     margin: 0;
   }
 }
@@ -14,13 +14,13 @@ mat-expansion-panel-header {
 }
 
 mat-panel-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
   background-color: transparent;
 }
 
 mat-expansion-panel-header.cdk-keyboard-focused,
 mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
-  background-color: $card-title-focus-background-color !important;
+  background-color: common.$card-title-focus-background-color !important;
 }
 
 .mat-expanded mat-expansion-panel-header {
@@ -33,29 +33,29 @@ b {
 }
 
 ul {
-  @include ul-flat;
+  @include common.ul-flat;
 }
 
 :host.dark-theme {
   border: none;
 
   mat-expansion-panel {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-panel-title {
     background-color: transparent;
-    color: $dark-theme-card-title-color;
+    color: common.$dark-theme-card-title-color;
   }
 
   mat-expansion-panel-header {
-    background-color: $dark-theme-card-title-background-color;
+    background-color: common.$dark-theme-card-title-background-color;
     margin: 0;
   }
 
   mat-expansion-panel-header.cdk-keyboard-focused,
   mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
-    background-color: $dark-theme-card-title-focus-background-color !important;
+    background-color: common.$dark-theme-card-title-focus-background-color !important;
   }
 
   .table {

--- a/frontend/app/components/overview_page/overview_page.scss
+++ b/frontend/app/components/overview_page/overview_page.scss
@@ -1,6 +1,6 @@
 /** CSS for an overview page component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -27,7 +27,7 @@
 }
 
 .full-column {
-  @include border-right-gray;
+  @include common.border-right-gray;
   width: 100%;
 }
 

--- a/frontend/app/components/overview_page/performance_summary/performance_summary.scss
+++ b/frontend/app/components/overview_page/performance_summary/performance_summary.scss
@@ -1,24 +1,24 @@
 /** CSS for a performance summary view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
 }
 
 :host:not(.dark-theme) {
   mat-card {
-    @include overview-card;
+    @include common.overview-card;
   }
 }
 
 mat-card {
-  @include overview-card-height;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
 }
 
 b {
@@ -26,7 +26,7 @@ b {
 }
 
 ul {
-  @include ul-flat;
+  @include common.ul-flat;
 }
 
 table {
@@ -93,12 +93,12 @@ table ul {
   border: none;
 
   mat-card {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-card-title {
-    background-color: $dark-theme-card-title-background-color;
-    color: $dark-theme-card-title-color;
+    background-color: common.$dark-theme-card-title-background-color;
+    color: common.$dark-theme-card-title-color;
     padding: 16px;
     margin: -16px -16px 16px;
   }

--- a/frontend/app/components/overview_page/run_environment_view/run_environment_view.scss
+++ b/frontend/app/components/overview_page/run_environment_view/run_environment_view.scss
@@ -1,25 +1,25 @@
 /** CSS for a run environment view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
   flex-grow: 1;
 }
 
 :host:not(.dark-theme) {
   mat-card {
-    @include overview-card;
+    @include common.overview-card;
   }
 }
 
 mat-card {
-  @include overview-card-height;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
 }
 
 b {
@@ -30,12 +30,12 @@ b {
   border: none;
 
   mat-card {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-card-title {
-    background-color: $dark-theme-card-title-background-color;
-    color: $dark-theme-card-title-color;
+    background-color: common.$dark-theme-card-title-background-color;
+    color: common.$dark-theme-card-title-color;
     padding: 16px;
     margin: -16px -16px 16px;
   }

--- a/frontend/app/components/overview_page/step_time_graph/step_time_graph.scss
+++ b/frontend/app/components/overview_page/step_time_graph/step_time_graph.scss
@@ -1,24 +1,24 @@
 /** CSS for a step-time graph view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
 }
 
 :host:not(.dark-theme) {
   mat-card {
-    @include overview-card;
+    @include common.overview-card;
   }
 }
 
 mat-card {
-  @include overview-card-height;
+  @include common.overview-card-height;
 }
 
 mat-card-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
 }
 
 .chart {
@@ -30,12 +30,12 @@ mat-card-title {
   border: none;
 
   mat-card {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-card-title {
-    background-color: $dark-theme-card-title-background-color;
-    color: $dark-theme-card-title-color;
+    background-color: common.$dark-theme-card-title-background-color;
+    color: common.$dark-theme-card-title-color;
     padding: 16px;
     margin: -16px -16px 16px;
   }

--- a/frontend/app/components/pod_viewer/pod_viewer.scss
+++ b/frontend/app/components/pod_viewer/pod_viewer.scss
@@ -1,6 +1,6 @@
 /** CSS for a pod viewer component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -20,5 +20,5 @@ mat-slider {
 }
 
 .control {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
 }

--- a/frontend/app/components/pod_viewer/pod_viewer_details/pod_viewer_details.scss
+++ b/frontend/app/components/pod_viewer/pod_viewer_details/pod_viewer_details.scss
@@ -1,6 +1,6 @@
 /** CSS for a pod viewer detail view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -8,7 +8,7 @@
 }
 
 mat-card {
-  @include detail-card;
+  @include common.detail-card;
 }
 
 .info-header {
@@ -18,7 +18,7 @@ mat-card {
 }
 
 .info-content {
-  color: $content-primary-color;
+  color: common.$content-primary-color;
   padding: 16px;
 }
 

--- a/frontend/app/components/pod_viewer/topology_graph/topology_graph.scss
+++ b/frontend/app/components/pod_viewer/topology_graph/topology_graph.scss
@@ -1,6 +1,6 @@
 /** CSS for a topology graph view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;
@@ -134,5 +134,5 @@
 }
 
 .control {
-  color: $content-secondary-color;
+  color: common.$content-secondary-color;
 }

--- a/frontend/app/components/roofline_model/roofline_model.scss
+++ b/frontend/app/components/roofline_model/roofline_model.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
   display: block;

--- a/frontend/app/components/sidenav/sidenav.scss
+++ b/frontend/app/components/sidenav/sidenav.scss
@@ -1,6 +1,6 @@
 /** CSS for a side navigation component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .button-container {
   padding: 20px;

--- a/frontend/app/components/smart_suggestion/smart_suggestion_view.scss
+++ b/frontend/app/components/smart_suggestion/smart_suggestion_view.scss
@@ -1,10 +1,10 @@
 /** CSS for a smart suggestion view component. */
 
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 :host {
-  @include border-bottom-gray;
-  @include border-right-gray;
+  @include common.border-bottom-gray;
+  @include common.border-right-gray;
 }
 
 // Styles for the outer list wrapping each suggestion block
@@ -86,7 +86,7 @@
 :host:not(.dark-theme) {
   mat-expansion-panel {
     margin: 0;
-    @include overview-card;
+    @include common.overview-card;
   }
 }
 
@@ -95,7 +95,7 @@ mat-expansion-panel-header {
 }
 
 mat-panel-title {
-  @include overview-card-title;
+  @include common.overview-card-title;
   background-color: transparent;
 }
 
@@ -117,7 +117,7 @@ mat-panel-title {
 
 mat-expansion-panel-header.cdk-keyboard-focused,
 mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
-  background-color: $card-title-focus-background-color;
+  background-color: common.$card-title-focus-background-color;
 }
 
 .mat-expanded mat-expansion-panel-header {
@@ -129,22 +129,22 @@ mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
   border: none;
 
   mat-expansion-panel {
-    @include overview-card-dark-theme;
+    @include common.overview-card-dark-theme;
   }
 
   mat-panel-title {
     background-color: transparent;
-    color: $dark-theme-card-title-color;
+    color: common.$dark-theme-card-title-color;
   }
 
   mat-expansion-panel-header {
-    background-color: $dark-theme-card-title-background-color;
+    background-color: common.$dark-theme-card-title-background-color;
     margin: 0;
   }
 
   mat-expansion-panel-header.cdk-keyboard-focused,
   mat-expansion-panel:not(.mat-expanded) mat-expansion-panel-header:hover {
-    background-color: $dark-theme-card-title-focus-background-color;
+    background-color: common.$dark-theme-card-title-focus-background-color;
   }
 
   .table {

--- a/frontend/app/components/source_mapper/source_mapper.scss
+++ b/frontend/app/components/source_mapper/source_mapper.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .source-mapper .text-ir-header {
   padding: 2px 5px;
@@ -6,7 +6,7 @@
   border-radius: 0;
   min-height: 20px;
   max-height: 20px;
-  font-family: $code-font-family;
+  font-family: common.$code-font-family;
   white-space: nowrap;
 }
 
@@ -54,7 +54,7 @@
   border-radius: 0;
   min-height: 20px;
   max-height: 20px;
-  font-family: $code-font-family;
+  font-family: common.$code-font-family;
   white-space: nowrap;
 }
 

--- a/frontend/app/components/stack_trace_page/stack_trace_page.scss
+++ b/frontend/app/components/stack_trace_page/stack_trace_page.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .info-table {
   border-collapse: collapse;

--- a/frontend/app/components/stack_trace_snippet/message.scss
+++ b/frontend/app/components/stack_trace_snippet/message.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .center-wrapper {
   display: flex;

--- a/frontend/app/components/stack_trace_snippet/stack_frame_snippet.scss
+++ b/frontend/app/components/stack_trace_snippet/stack_frame_snippet.scss
@@ -1,4 +1,4 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';
 
 .stack-frame-snippet {
   border-radius: 0;
@@ -16,12 +16,12 @@
   border-radius: 0;
   min-height: 20px;
   max-height: 20px;
-  font-family: $code-font-family;
+  font-family: common.$code-font-family;
   white-space: nowrap;
 }
 
 .stack-frame-snippet code {
-  font-family: $code-font-family;
+  font-family: common.$code-font-family;
   font-size: 0.8125em;
 }
 

--- a/frontend/app/components/stack_trace_snippet/stack_trace_snippet.scss
+++ b/frontend/app/components/stack_trace_snippet/stack_trace_snippet.scss
@@ -1,1 +1,1 @@
-@import 'frontend/app/styles/common';
+@use 'frontend/app/styles/common';

--- a/frontend/styles.scss
+++ b/frontend/styles.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '@angular/material' as mat;
 
 :root {
@@ -51,7 +52,7 @@ $theme: mat.define-light-theme(
 @include mat.dialog-theme($theme);
 @include mat.progress-spinner-theme($theme);
 @include mat.progress-bar-theme($theme);
-@include mat.slide-toggle-theme(map-merge($theme, (density: -5)));
+@include mat.slide-toggle-theme(map.merge($theme, (density: -5)));
 @include mat.radio-theme($theme);
 @include mat.snack-bar-theme($theme);
 @include mat.slider-theme($theme);


### PR DESCRIPTION
`@import` is deprecated in Sass and will be removed from the language in Dart Sass 3.0.0.

This is a no-op change migrating `@import` to `@use` and adding namespaces for variables and mixins from dependencies. It also migrates a use of the global `map-merge` function to the equivalent `map.merge` function in the built-in `sass:map` module (adding a `@use` rule for it as well).