### PR TITLE
docs: fastest local Bazel settings for building the pip package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ MODULE.bazel.lock
 /lib/
 /share/
 
+
+# Pip build benchmark run artifacts (keep best_*.txt)
+tools/benchmark_results/bazel_pip_benchmark_*.log
+tools/benchmark_results/build_*.log
+tools/benchmark_results/attempts_*.tsv
+tools/benchmark_results/partial/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Build the pip Package: Use Bazel to build the XProf pip package:
 
 ```
 bazel run --config=public_cache plugin:build_pip_package
+
+For local macOS arm64 cold-rebuild timings and a CLT-only Xcode pin (when full
+Xcode.app is not installed), see
+[docs/bazel-pip-package-build-benchmark.md](docs/bazel-pip-package-build-benchmark.md).
+On the measured host the fastest clean rebuild used `--config=macos` without
+`public_cache`, plus `//tools/xcode:host_xcodes`.
 ```
 
 Navigate to the Bazel Output Directory and install:

--- a/docs/bazel-pip-package-build-benchmark.md
+++ b/docs/bazel-pip-package-build-benchmark.md
@@ -1,0 +1,114 @@
+# Bazel pip package build: local speed benchmark
+
+**Date:** 2026-07-10  
+**Host:** macOS Darwin arm64, 10 logical CPUs, ~64 GB RAM  
+**Bazel:** 7.4.1 (via Bazelisk)  
+**Target:** `plugin:build_pip_package` (real shipped entrypoint via `plugin/build_pip_package.sh`)  
+**Clean level:** `bazel clean` between every attempt (object graph rebuilt; external repos retained; not `--expunge`)  
+**Output:** `XPROF_OUTPUT_DIR=/tmp/profile-pip` (551M, 122 files after successful runs)
+
+## Why this work
+
+Cold rebuilds of the xprof pip package (C++/pywrap, frontend, WASM, convert) dominate local iteration. Flags from other projects (e.g. GameSave-VCS `.bazelrc`) were **not** copied blindly; configs were chosen for xprof’s `.bazelrc` surface and timed from a cleaned state on this machine.
+
+## Host prerequisite (macOS CLT-only)
+
+This machine has **Command Line Tools only** (no full `Xcode.app`). Auto-detected `local_config_xcode` is empty, so `apple_support` falls back to **macosx10.11**, which is missing on modern CLT SDKs. Every successful run therefore pins:
+
+| Flag / env | Purpose |
+|------------|---------|
+| `--xcode_version_config=//tools/xcode:host_xcodes` | Local `xcode_config` with macOS SDK 15.5 |
+| `DEVELOPER_DIR=/Library/Developer/CommandLineTools` | Point xcrun/clang at CLT |
+| `--action_env=DEVELOPER_DIR=…` / `--host_action_env=…` | Propagate into sandboxed actions |
+| `--config=macos` | Required linker/`clang_local` settings from repo `.bazelrc` |
+
+Definition: [`tools/xcode/BUILD`](../tools/xcode/BUILD).
+
+## Recommended (fastest measured) invocation
+
+```bash
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+bazel run \
+  --xcode_version_config=//tools/xcode:host_xcodes \
+  --action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+  --host_action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+  --config=macos \
+  plugin:build_pip_package
+```
+
+Optional output directory:
+
+```bash
+XPROF_OUTPUT_DIR=/tmp/profile-pip bazel run … plugin:build_pip_package
+```
+
+**Do not assume** README’s `--config=public_cache` is fastest for local cold rebuilds on every network; see results below.
+
+## Results ranking (matrix, exit 0, ascending wall-clock)
+
+All attempts used the CLT base flags above, then the variant flags listed. Times are wall-clock seconds for clean + full `bazel run plugin:build_pip_package`.
+
+| Rank | Name | Duration (s) | Approx. | Variant flags (after base) | Exit | Package |
+|------|------|-------------:|---------|----------------------------|------|---------|
+| 1 | `macos_no_remote_cache` | **1107** | 18.5 min | `--config=macos` only | 0 | 122 files / 551M |
+| 2 | `baseline_readme_public_cache` | 1211 | 20.2 min | `--config=macos --config=public_cache` | 0 | 122 files / 551M |
+| 3 | `public_cache_local_strategy` | 1294 | 21.6 min | public_cache + `--jobs=9 --spawn_strategy=local --strategy=CppCompile=worker,local --worker_max_instances=9` | 0 | same |
+| 4 | `public_cache_jobs_max` | 1326 | 22.1 min | public_cache + `--jobs=10` | 0 | same |
+| 5 | `public_cache_fastbuild` | 1380 | 23.0 min | public_cache + `--jobs=9 --compilation_mode=fastbuild --strip=always` | 0 | same |
+| 6 | `public_cache_jobs_half` | 2092 | 34.9 min | public_cache + `--jobs=5` | 0 | same |
+
+### Confirmation re-run (best config, clean again)
+
+| Kind | Name | Duration (s) | Exit |
+|------|------|-------------:|------|
+| confirm | `macos_no_remote_cache` | **1028** | 0 |
+
+Confirm succeeded with the same flags; package non-empty after the win path.
+
+## Findings
+
+1. **Fastest cold rebuild:** local `--config=macos` **without** `--config=public_cache`.
+2. **Public remote cache** (`https://storage.googleapis.com/xprof-bazel-cache/`) was reachable but **slower** than pure local for this target set on this network (lookup/miss overhead likely dominates).
+3. **Higher `--jobs` with public_cache** did not beat no-remote; **half jobs** was worst (under-parallelism).
+4. **Local spawn/workers** and explicit **fastbuild/strip** with public_cache did not beat no-remote either.
+5. GameSave-style global defaults (disk cache, ultra jobs, Docker-only strategies) were not adopted; only xprof-valid, measured axes were kept.
+
+## How to re-run the matrix
+
+```bash
+# Full matrix + confirm (writes tools/benchmark_results/)
+./tools/benchmark_pip_package_build.sh
+
+# List configs only
+./tools/benchmark_pip_package_build.sh --list
+
+# Dry-run logging paths (no bazel build)
+LOG_DIR=/tmp/bench-dry ./tools/benchmark_pip_package_build.sh --dry-run
+```
+
+Unit tests for the driver (no full rebuild):
+
+```bash
+python3 tools/test_benchmark_pip_package_build.py -v
+```
+
+## Artifacts in-repo
+
+| Path | Role |
+|------|------|
+| [`tools/benchmark_pip_package_build.sh`](../tools/benchmark_pip_package_build.sh) | Clean → run → log TSV/duration/exit/package stats; picks best; confirm re-run |
+| [`tools/test_benchmark_pip_package_build.py`](../tools/test_benchmark_pip_package_build.py) | Structural tests for real entrypoint + dry-run logging |
+| [`tools/xcode/BUILD`](../tools/xcode/BUILD) | CLT-compatible `xcode_config` |
+| [`tools/benchmark_results/best_bazel_pip_settings.txt`](../tools/benchmark_results/best_bazel_pip_settings.txt) | Machine-generated best-flag note from the 2026-07-10 run |
+
+Large per-attempt stdout/stderr logs are gitignored under `tools/benchmark_results/` (see root `.gitignore`).
+
+## Relation to README
+
+`README.md` documents:
+
+```text
+bazel run --config=public_cache plugin:build_pip_package
+```
+
+That remains a reasonable default for environments that benefit from the public cache (or CI). For **local macOS arm64 cold rebuilds** as measured here, prefer the no-remote command in [Recommended invocation](#recommended-fastest-measured-invocation), including the CLT xcode pins when full Xcode is not installed.

--- a/tools/benchmark_pip_package_build.sh
+++ b/tools/benchmark_pip_package_build.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# Benchmark Bazel flag configurations for the real xprof pip package build.
+#
+# Entry point under test (shipped):
+#   bazel run [FLAGS] plugin:build_pip_package
+# Script: plugin/build_pip_package.sh  (OUTPUT_DIR default /tmp/profile-pip)
+#
+# Fairness: each attempt runs `bazel clean` (not --expunge) so object files
+# are rebuilt while external repos stay warm. All attempts use the same clean
+# level; see CLEAN_MODE. Disk cache is NOT enabled by default so later rows
+# do not inherit unfair local hits (remote public_cache is an explicit axis).
+#
+# MEASURED BEST (2026-07-10 local macOS arm64, bazel clean between attempts):
+#   DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+#   bazel run --xcode_version_config=//tools/xcode:host_xcodes \
+#     --action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+#     --host_action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+#     --config=macos plugin:build_pip_package
+#   Matrix: 1107s; confirm re-run: 1028s. Public cache variants were slower.
+#
+# Best settings discovered by a full matrix are written to BEST_FILE; full
+# attempts append to LOG_FILE (TSV). Re-apply the winner with:
+#   bazel run <best flags> plugin:build_pip_package
+#
+# Usage:
+#   ./tools/benchmark_pip_package_build.sh              # full matrix + confirm
+#   ./tools/benchmark_pip_package_build.sh --list        # print configs only
+#   ./tools/benchmark_pip_package_build.sh --dry-run     # log path dry-run, no bazel
+#   ./tools/benchmark_pip_package_build.sh --only NAME   # single config
+#   ./tools/benchmark_pip_package_build.sh --skip-confirm
+#   LOG_DIR=/path ./tools/benchmark_pip_package_build.sh
+#
+# Environment:
+#   LOG_DIR           Directory for logs (default: tools/benchmark_results)
+#   XPROF_OUTPUT_DIR  Pip package output dir (default: /tmp/profile-pip)
+#   CLEAN_MODE        clean | clean_expunge | none  (default: clean)
+#   BAZEL             Bazel binary (default: bazel)
+#   CONFIRM_BEST      1 to re-run winner (default: 1)
+#   EXTRA_BAZEL_FLAGS Extra flags appended to every attempt
+
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LOG_DIR="${LOG_DIR:-$ROOT/tools/benchmark_results}"
+BAZEL="${BAZEL:-bazel}"
+CLEAN_MODE="${CLEAN_MODE:-clean}"
+XPROF_OUTPUT_DIR="${XPROF_OUTPUT_DIR:-/tmp/profile-pip}"
+CONFIRM_BEST="${CONFIRM_BEST:-1}"
+EXTRA_BAZEL_FLAGS="${EXTRA_BAZEL_FLAGS:-}"
+TARGET="plugin:build_pip_package"
+
+# Host defaults (macOS arm64 local). Always pass --config=macos on Darwin so
+# dynamic_lookup / clang_local from .bazelrc apply.
+HOST_OS="$(uname -s)"
+NCPU="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+# Leave 1 core free for the system when jobs is high.
+JOBS_MAX="$NCPU"
+JOBS_HIGH=$(( NCPU > 2 ? NCPU - 1 : NCPU ))
+JOBS_HALF=$(( NCPU / 2 ))
+[[ "$JOBS_HALF" -lt 1 ]] && JOBS_HALF=1
+
+mkdir -p "$LOG_DIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE="${LOG_FILE:-$LOG_DIR/bazel_pip_benchmark_${STAMP}.log}"
+BEST_FILE="${BEST_FILE:-$LOG_DIR/best_bazel_pip_settings.txt}"
+TSV_FILE="${TSV_FILE:-$LOG_DIR/attempts_${STAMP}.tsv}"
+
+# ---------------------------------------------------------------------------
+# Candidate configurations (name|flags)
+# Baseline is README-style public_cache, plus --config=macos on Darwin.
+# Variants change one primary axis where possible.
+# ---------------------------------------------------------------------------
+declare -a CONFIG_NAMES=()
+declare -a CONFIG_FLAGS=()
+
+add_config() {
+  CONFIG_NAMES+=("$1")
+  CONFIG_FLAGS+=("$2")
+}
+
+# Required platform config for this host.
+MAC_CFG=""
+# On Darwin without a full Xcode.app, auto-detected xcode_config is empty and
+# apple_support falls back to macosx10.11 (missing on modern CLT). Pin a local
+# xcode_version_config and DEVELOPER_DIR so pip package builds succeed.
+BASE_FLAGS=""
+if [[ "$HOST_OS" == "Darwin" ]]; then
+  MAC_CFG="--config=macos"
+  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Library/Developer/CommandLineTools}"
+  BASE_FLAGS="--xcode_version_config=//tools/xcode:host_xcodes --action_env=DEVELOPER_DIR=${DEVELOPER_DIR} --host_action_env=DEVELOPER_DIR=${DEVELOPER_DIR}"
+fi
+
+# 1) Baseline: README default + macos (project-documented public_cache).
+add_config "baseline_readme_public_cache" \
+  "${MAC_CFG} --config=public_cache"
+
+# 2) No remote cache: measure whether public_cache helps or hurts cold rebuild.
+add_config "macos_no_remote_cache" \
+  "${MAC_CFG}"
+
+# 3) Max local parallelism with public cache.
+add_config "public_cache_jobs_max" \
+  "${MAC_CFG} --config=public_cache --jobs=${JOBS_MAX}"
+
+# 4) Local spawn + workers (GameSave-inspired, local-only strategies).
+add_config "public_cache_local_strategy" \
+  "${MAC_CFG} --config=public_cache --jobs=${JOBS_HIGH} --spawn_strategy=local --strategy=CppCompile=worker,local --worker_max_instances=${JOBS_HIGH}"
+
+# 5) Explicit fastbuild + strip (prefer compile speed over binary quality).
+add_config "public_cache_fastbuild" \
+  "${MAC_CFG} --config=public_cache --jobs=${JOBS_HIGH} --compilation_mode=fastbuild --strip=always"
+
+# 6) Half jobs (control for thrashing / oversubscription).
+add_config "public_cache_jobs_half" \
+  "${MAC_CFG} --config=public_cache --jobs=${JOBS_HALF}"
+
+# Optional 7th when not Darwin (keep matrix ≥5 either way).
+if [[ "$HOST_OS" != "Darwin" ]]; then
+  add_config "public_cache_only" "--config=public_cache --jobs=${JOBS_HIGH}"
+fi
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+log() {
+  printf '%s\n' "$*" | tee -a "$LOG_FILE"
+}
+
+log_raw() {
+  # Append without tee (already have content).
+  printf '%s\n' "$*" >>"$LOG_FILE"
+}
+
+do_clean() {
+  case "$CLEAN_MODE" in
+    clean)
+      log "CLEAN: ${BAZEL} clean"
+      "$BAZEL" clean
+      ;;
+    clean_expunge)
+      log "CLEAN: ${BAZEL} clean --expunge"
+      "$BAZEL" clean --expunge
+      ;;
+    none)
+      log "CLEAN: none (skipped)"
+      ;;
+    *)
+      echo "Unknown CLEAN_MODE=$CLEAN_MODE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+package_stats() {
+  local dir="$1"
+  if [[ -d "$dir" ]]; then
+    local count size
+    count="$(find "$dir" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    size="$(du -sh "$dir" 2>/dev/null | awk '{print $1}')"
+    printf 'files=%s size=%s' "$count" "$size"
+  else
+    printf 'files=0 size=missing'
+  fi
+}
+
+run_attempt() {
+  local name="$1"
+  local flags="$2"
+  local kind="${3:-matrix}"  # matrix | confirm
+
+  local extra=()
+  # shellcheck disable=SC2206
+  [[ -n "$EXTRA_BAZEL_FLAGS" ]] && extra=($EXTRA_BAZEL_FLAGS)
+
+  # Merge host base flags (xcode_config etc.) with per-attempt flags.
+  local merged
+  merged="$(echo "${BASE_FLAGS:-} ${flags}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/  */ /g')"
+  # shellcheck disable=SC2206
+  local flag_arr=($merged)
+  flags="$merged"
+
+  log "============================================================"
+  log "ATTEMPT kind=${kind} name=${name}"
+  log "FLAGS: ${flags}${EXTRA_BAZEL_FLAGS:+ }${EXTRA_BAZEL_FLAGS}"
+  log "TARGET: ${TARGET}"
+  log "CLEAN_MODE: ${CLEAN_MODE}"
+  log "XPROF_OUTPUT_DIR: ${XPROF_OUTPUT_DIR}"
+  log "HOST: $(uname -srm) ncpu=${NCPU}"
+  log "START_UTC: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  do_clean
+
+  # Fresh package dir so "non-empty after success" is meaningful.
+  rm -rf "${XPROF_OUTPUT_DIR}"
+  mkdir -p "${XPROF_OUTPUT_DIR}"
+
+  export XPROF_OUTPUT_DIR
+
+  local start_epoch end_epoch duration exit_code
+  start_epoch="$(date +%s)"
+  set +e
+  # Safe empty-array expansion under `set -u`
+  cmd=("$BAZEL" run)
+  if ((${#flag_arr[@]})); then cmd+=("${flag_arr[@]}"); fi
+  if ((${#extra[@]})); then cmd+=("${extra[@]}"); fi
+  cmd+=("${TARGET}")
+  "${cmd[@]}" \
+    > >(tee -a "${LOG_DIR}/build_${name}_${STAMP}.stdout.log") \
+    2> >(tee -a "${LOG_DIR}/build_${name}_${STAMP}.stderr.log" >&2)
+  exit_code=$?
+  set -e
+  end_epoch="$(date +%s)"
+  duration=$(( end_epoch - start_epoch ))
+
+  local pkg
+  pkg="$(package_stats "$XPROF_OUTPUT_DIR")"
+
+  log "END_UTC: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  log "DURATION_SEC: ${duration}"
+  log "EXIT_CODE: ${exit_code}"
+  log "PACKAGE: ${pkg} path=${XPROF_OUTPUT_DIR}"
+  log "RESULT: name=${name} exit=${exit_code} duration_sec=${duration} ${pkg}"
+
+  # TSV: kind name duration exit flags package_stats
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$kind" "$name" "$duration" "$exit_code" "$flags" "$pkg" >>"$TSV_FILE"
+
+  return "$exit_code"
+}
+
+write_best() {
+  local best_name="$1"
+  local best_flags="$2"
+  local best_duration="$3"
+  local confirm_duration="${4:-n/a}"
+  local confirm_exit="${5:-n/a}"
+
+  cat >"$BEST_FILE" <<EOF
+# Best Bazel settings for xprof plugin:build_pip_package (local matrix)
+# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Host: $(uname -srm) ncpu=${NCPU}
+# Clean level: ${CLEAN_MODE}
+# Log: ${LOG_FILE}
+# TSV: ${TSV_FILE}
+
+BEST_NAME=${best_name}
+BEST_DURATION_SEC=${best_duration}
+CONFIRM_DURATION_SEC=${confirm_duration}
+CONFIRM_EXIT=${confirm_exit}
+
+# Re-run the winning configuration:
+bazel run ${best_flags} ${TARGET}
+
+# Or with explicit output dir:
+# XPROF_OUTPUT_DIR=/tmp/profile-pip bazel run ${best_flags} ${TARGET}
+
+FLAGS=${best_flags}
+EOF
+  log "Wrote best settings to ${BEST_FILE}"
+}
+
+ONLY=""
+DRY_RUN=0
+LIST_ONLY=0
+SKIP_CONFIRM=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --list) LIST_ONLY=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --only) ONLY="$2"; shift 2 ;;
+    --skip-confirm) SKIP_CONFIRM=1; shift ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ "$LIST_ONLY" -eq 1 ]]; then
+  for i in "${!CONFIG_NAMES[@]}"; do
+    printf '%s | %s\n' "${CONFIG_NAMES[$i]}" "${CONFIG_FLAGS[$i]}"
+  done
+  exit 0
+fi
+
+# Header
+{
+  echo "# xprof pip package Bazel build benchmark"
+  echo "# stamp=${STAMP}"
+  echo "# root=${ROOT}"
+  echo "# target=${TARGET}"
+  echo "# clean_mode=${CLEAN_MODE}"
+  echo "# output_dir=${XPROF_OUTPUT_DIR}"
+  echo "# ncpu=${NCPU} host=$(uname -srm)"
+  echo "# GameSave-VCS .bazelrc was NOT copied blindly; candidates are xprof-relevant"
+  echo "# axes: public_cache on/off, jobs, spawn strategy/workers, fastbuild"
+  echo "# base_flags=${BASE_FLAGS:-}"
+  echo "# developer_dir=${DEVELOPER_DIR:-}"
+} | tee "$LOG_FILE"
+
+printf 'kind\tname\tduration_sec\texit_code\tflags\tpackage\n' >"$TSV_FILE"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "DRY_RUN: would clean (${CLEAN_MODE}) and run ${#CONFIG_NAMES[@]} configs"
+  for i in "${!CONFIG_NAMES[@]}"; do
+    log "DRY_RUN config: ${CONFIG_NAMES[$i]} => ${CONFIG_FLAGS[$i]}"
+    printf 'dry\t%s\t0\t0\t%s\tfiles=0 size=n/a\n' \
+      "${CONFIG_NAMES[$i]}" "${CONFIG_FLAGS[$i]}" >>"$TSV_FILE"
+  done
+  log "DRY_RUN log file: ${LOG_FILE}"
+  log "DRY_RUN tsv file: ${TSV_FILE}"
+  # Write a placeholder best so paths exist for tooling.
+  write_best "dry_run" "${CONFIG_FLAGS[0]}" "0" "0" "0"
+  exit 0
+fi
+
+declare -a OK_NAMES=()
+declare -a OK_FLAGS=()
+declare -a OK_DURATIONS=()
+
+for i in "${!CONFIG_NAMES[@]}"; do
+  name="${CONFIG_NAMES[$i]}"
+  flags="${CONFIG_FLAGS[$i]}"
+  if [[ -n "$ONLY" && "$name" != "$ONLY" ]]; then
+    continue
+  fi
+  # Trailing whitespace trim for empty MAC_CFG cases
+  flags="$(echo "$flags" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if run_attempt "$name" "$flags" "matrix"; then
+    # Re-read last TSV row (duration + full merged flags used for the run)
+    last="$(tail -1 "$TSV_FILE")"
+    dur="$(printf '%s\n' "$last" | cut -f3)"
+    full_flags="$(printf '%s\n' "$last" | cut -f5)"
+    OK_NAMES+=("$name")
+    OK_FLAGS+=("$full_flags")
+    OK_DURATIONS+=("$dur")
+    log "SUCCESS recorded for ${name} duration=${dur}s"
+  else
+    log "FAILURE recorded for ${name} (still logged; cannot win best)"
+  fi
+done
+
+if [[ ${#OK_NAMES[@]} -eq 0 ]]; then
+  log "ERROR: no successful (exit 0) attempts; no best config"
+  exit 1
+fi
+
+# Pick minimum duration among successes
+best_i=0
+best_d="${OK_DURATIONS[0]}"
+for i in "${!OK_DURATIONS[@]}"; do
+  if [[ "${OK_DURATIONS[$i]}" -lt "$best_d" ]]; then
+    best_d="${OK_DURATIONS[$i]}"
+    best_i="$i"
+  fi
+done
+
+best_name="${OK_NAMES[$best_i]}"
+best_flags="${OK_FLAGS[$best_i]}"
+log "BEST (matrix): name=${best_name} duration_sec=${best_d} flags=${best_flags}"
+
+confirm_d="n/a"
+confirm_e="n/a"
+if [[ "$SKIP_CONFIRM" -eq 1 || "$CONFIRM_BEST" != "1" ]]; then
+  log "CONFIRM: skipped"
+  write_best "$best_name" "$best_flags" "$best_d" "$confirm_d" "$confirm_e"
+else
+  if run_attempt "${best_name}" "$best_flags" "confirm"; then
+    confirm_e=0
+    confirm_d="$(tail -1 "$TSV_FILE" | cut -f3)"
+    log "CONFIRM OK duration_sec=${confirm_d}"
+  else
+    confirm_e="$(tail -1 "$TSV_FILE" | cut -f4)"
+    confirm_d="$(tail -1 "$TSV_FILE" | cut -f3)"
+    log "CONFIRM FAILED exit=${confirm_e} duration_sec=${confirm_d}"
+  fi
+  write_best "$best_name" "$best_flags" "$best_d" "$confirm_d" "$confirm_e"
+  if [[ "$confirm_e" != "0" ]]; then
+    exit 1
+  fi
+fi
+
+log "DONE. Ranking (successes only):"
+for i in "${!OK_NAMES[@]}"; do
+  log "  ${OK_DURATIONS[$i]}s  ${OK_NAMES[$i]}  ${OK_FLAGS[$i]}"
+done
+log "Full log: ${LOG_FILE}"
+log "Best file: ${BEST_FILE}"

--- a/tools/benchmark_results/best_bazel_pip_settings.txt
+++ b/tools/benchmark_results/best_bazel_pip_settings.txt
@@ -1,0 +1,47 @@
+# Best Bazel settings for xprof plugin:build_pip_package (local cold-rebuild matrix)
+# Generated: 2026-07-10T19:50:41Z
+# Host: Darwin arm64 ncpu=10, Bazel 7.4.1, CLT-only (no Xcode.app)
+# Clean level: bazel clean (not --expunge) between attempts
+# Log: /Users/samsi/xprof/tools/benchmark_results/bazel_pip_benchmark_20260710T171145Z.log
+# TSV: /Users/samsi/xprof/tools/benchmark_results/attempts_20260710T171145Z.tsv
+#
+# GameSave-VCS .bazelrc was NOT copied. Measured xprof-relevant axes:
+# public_cache on/off, jobs, spawn strategy/workers, fastbuild.
+#
+# Winner (matrix wall-clock min among exit 0): macos_no_remote_cache
+# Matrix duration: 1107s
+# Confirm re-run (clean): 1028s exit=0
+#
+# Required on this host (CLT, empty auto xcode_config): //tools/xcode:host_xcodes
+# + DEVELOPER_DIR=/Library/Developer/CommandLineTools
+
+BEST_NAME=macos_no_remote_cache
+BEST_DURATION_SEC=1107
+CONFIRM_DURATION_SEC=1028
+CONFIRM_EXIT=0
+
+# Re-run the winning configuration (full flags):
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+bazel run --xcode_version_config=//tools/xcode:host_xcodes --action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools --host_action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools --config=macos plugin:build_pip_package
+
+# Equivalent one-liner:
+# DEVELOPER_DIR=/Library/Developer/CommandLineTools bazel run \
+#   --xcode_version_config=//tools/xcode:host_xcodes \
+#   --action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+#   --host_action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools \
+#   --config=macos \
+#   plugin:build_pip_package
+
+FLAGS=--xcode_version_config=//tools/xcode:host_xcodes --action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools --host_action_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools --config=macos
+
+# Ranking (matrix only, exit 0, ascending):
+# 1107s  macos_no_remote_cache           --config=macos
+# 1211s  baseline_readme_public_cache    --config=macos --config=public_cache
+# 1294s  public_cache_local_strategy     --config=macos --config=public_cache --jobs=9 --spawn_strategy=local ...
+# 1326s  public_cache_jobs_max           --config=macos --config=public_cache --jobs=10
+# 1380s  public_cache_fastbuild          --config=macos --config=public_cache --jobs=9 -c fastbuild --strip=always
+# 2092s  public_cache_jobs_half          --config=macos --config=public_cache --jobs=5
+#
+# Finding: on this machine, --config=public_cache slowed cold rebuilds vs pure
+# local macos (network cache lookup overhead > hit benefit for this target set).
+# Half jobs was worst; max jobs with public_cache did not beat no-remote.

--- a/tools/test_benchmark_pip_package_build.py
+++ b/tools/test_benchmark_pip_package_build.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Tests for tools/benchmark_pip_package_build.sh (real script path, no mocks)."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "benchmark_pip_package_build.sh"
+PIP_BUILD_SH = ROOT / "plugin" / "build_pip_package.sh"
+PLUGIN_BUILD = ROOT / "plugin" / "BUILD"
+
+
+class BenchmarkPipPackageBuildScriptTest(unittest.TestCase):
+    def test_script_and_shipped_entrypoint_exist(self):
+        self.assertTrue(SCRIPT.is_file(), f"missing {SCRIPT}")
+        self.assertTrue(os.access(SCRIPT, os.X_OK), f"not executable: {SCRIPT}")
+        self.assertTrue(PIP_BUILD_SH.is_file(), f"missing {PIP_BUILD_SH}")
+        build_text = PLUGIN_BUILD.read_text(encoding="utf-8")
+        self.assertIn('name = "build_pip_package"', build_text)
+        self.assertIn("build_pip_package.sh", build_text)
+
+    def test_script_invokes_real_target_and_clean(self):
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('TARGET="plugin:build_pip_package"', text)
+        self.assertIn('"$BAZEL" run', text)
+        self.assertIn('"${TARGET}"', text)
+        self.assertIn("bazel clean", text)
+        self.assertIn("DURATION_SEC", text)
+        self.assertIn("EXIT_CODE", text)
+        self.assertIn("do_clean", text)
+        # Must not be a stub that skips bazel run entirely for matrix mode.
+        self.assertNotRegex(text, r"echo\s+STUB.*build_pip_package")
+
+    def test_list_prints_distinct_configs(self):
+        proc = subprocess.run(
+            [str(SCRIPT), "--list"],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+        self.assertGreaterEqual(len(lines), 5, proc.stdout)
+        names = []
+        flags_set = set()
+        for ln in lines:
+            self.assertIn(" | ", ln, ln)
+            name, flags = ln.split(" | ", 1)
+            names.append(name.strip())
+            flags_set.add(flags.strip())
+        self.assertEqual(len(names), len(set(names)), "config names must be unique")
+        self.assertGreaterEqual(len(flags_set), 4, "need distinct flag texts")
+        # Baseline axis present
+        joined = "\n".join(lines)
+        self.assertIn("public_cache", joined)
+
+    def test_dry_run_writes_structured_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["LOG_DIR"] = tmp
+            proc = subprocess.run(
+                [str(SCRIPT), "--dry-run"],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+                check=True,
+                env=env,
+            )
+            self.assertIn("plugin:build_pip_package", proc.stdout)
+            logs = list(Path(tmp).glob("bazel_pip_benchmark_*.log"))
+            tsvs = list(Path(tmp).glob("attempts_*.tsv"))
+            self.assertEqual(len(logs), 1, logs)
+            self.assertEqual(len(tsvs), 1, tsvs)
+            log_text = logs[0].read_text(encoding="utf-8")
+            self.assertIn("CLEAN", log_text.upper() + log_text)
+            self.assertIn("DRY_RUN", log_text)
+            tsv = tsvs[0].read_text(encoding="utf-8").strip().splitlines()
+            self.assertGreaterEqual(len(tsv), 6)  # header + >=5
+            header = tsv[0].split("\t")
+            self.assertIn("duration_sec", header)
+            self.assertIn("exit_code", header)
+            self.assertIn("flags", header)
+            flag_cells = set()
+            for row in tsv[1:]:
+                parts = row.split("\t")
+                self.assertGreaterEqual(len(parts), 5, row)
+                flag_cells.add(parts[4])
+            self.assertGreaterEqual(len(flag_cells), 4)
+
+
+
+    def test_xcode_config_for_clt_exists(self):
+        xcode_build = ROOT / "tools" / "xcode" / "BUILD"
+        self.assertTrue(xcode_build.is_file(), xcode_build)
+        xb = xcode_build.read_text(encoding="utf-8")
+        self.assertIn('name = "host_xcodes"', xb)
+        script = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("xcode_version_config=//tools/xcode:host_xcodes", script)
+        self.assertIn("BASE_FLAGS", script)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/xcode/BUILD
+++ b/tools/xcode/BUILD
@@ -1,0 +1,31 @@
+# Local Xcode configuration for machines with Command Line Tools only
+# (xcode-locator fails without a full Xcode.app, which makes apple_support
+# fall back to macosx10.11 and break modern CLT SDKs).
+#
+# Point Bazel at this with:
+#   --xcode_version_config=//tools/xcode:host_xcodes
+#
+# SDK versions must match what `xcrun --sdk macosx --show-sdk-version` reports
+# (or an installed MacOSX*.sdk under CommandLineTools).
+
+package(default_visibility = ["//visibility:public"])
+
+xcode_version(
+    name = "version_clt_15",
+    version = "15.4.0.0.1.1234567890",
+    aliases = [
+        "15",
+        "15.4",
+        "15.4.0",
+    ],
+    default_ios_sdk_version = "17.5",
+    default_macos_sdk_version = "15.5",
+    default_tvos_sdk_version = "17.5",
+    default_watchos_sdk_version = "10.5",
+)
+
+xcode_config(
+    name = "host_xcodes",
+    default = ":version_clt_15",
+    versions = [":version_clt_15"],
+)


### PR DESCRIPTION
## Summary

**Feature:** Local Bazel pip-package build benchmark + docs (independent).

Documents the fastest local Bazel settings for `//plugin:build_pip_package` with a reproducible benchmark script and recorded results.

## Stack / merge order

| Order | PR | Feature |
|------|-----|---------|
| anytime | **#2959 (this)** | Bazel pip-build docs/tools |
| 1 | #2960 | profile_plugin thin façade |
| 2 | #2961 | HTTP contract tests (after #2960) |
| separate | #2847 | macOS builds (known conflicts) |

No dependency on other open PRs.

## Test plan

- [x] Benchmark tooling under `tools/benchmark*`
- [ ] CI