### PR TITLE
fix(profile_io): narrow GCS exceptions and document mTLS bypass

### DIFF
--- a/plugin/xprof/profile_io.py
+++ b/plugin/xprof/profile_io.py
@@ -44,22 +44,46 @@ except ImportError:
   gcs_exceptions = None
   storage = None
 
+# Errors that GcsFileSystem listing methods should catch and degrade on.
+# Programming errors (TypeError, AttributeError, etc.) intentionally propagate.
+if gcs_exceptions is not None:
+  _gcs_error_types = [gcs_exceptions.GoogleAPICallError, OSError, TimeoutError]
+  # RetryError is raised after exhausted retries; present on
+  # google.api_core.exceptions in some versions.
+  _retry_error = getattr(gcs_exceptions, 'RetryError', None)
+  if _retry_error is not None:
+    _gcs_error_types.append(_retry_error)
+  _GCS_ERRORS = tuple(_gcs_error_types)
+else:
+  _GCS_ERRORS = (OSError, TimeoutError, RuntimeError)
+
 
 @functools.lru_cache(maxsize=None)
 def get_storage_client():
-  """Returns a memoized storage client instance."""
+  """Returns a memoized storage client instance.
+
+  Builds the client with an AuthorizedSession that bypasses google-auth's
+  pyOpenSSL-based mTLS client-certificate path. On corporate machines,
+  pyOpenSSL is often installed and google-auth prefers it for mutual TLS, but
+  pyOpenSSL is incompatible with urllib3 >= 2.7. xprof only reads GCS blobs;
+  mutual TLS client certificates are intentionally not required for that use.
+
+  The ``_http=`` keyword is a private constructor argument on
+  ``google.cloud.storage.Client``. There is no public API to inject a custom
+  HTTP session while still using default credentials/project resolution, so
+  this private kwarg is intentionally retained.
+  """
   if storage is None:
     raise RuntimeError(
         'Google Cloud Storage libraries not found. gs:// paths are not'
         ' supported.'
     )
 
-  # google-auth tries to use pyOpenSSL for mTLS client
-  # certificates, but pyOpenSSL is incompatible with urllib3 >= 2.7.
-  # xprof only reads GCS blobs — mutual TLS is not required.
+  # Bypass google-auth's pyOpenSSL mTLS path (see docstring).
   if google_auth is not None and google_auth_requests is not None:
     credentials, project = google_auth.default()
     http_session = google_auth_requests.AuthorizedSession(credentials)
+    # _http= is private but required; no public session-injection API exists.
     return storage.Client(
         project=project, credentials=credentials, _http=http_session
     )
@@ -163,7 +187,7 @@ class GcsFileSystem(ProfileFileSystem):
           return None
         file_identifiers[os.path.basename(blob.name)] = md5_hash
       return file_identifiers
-    except Exception as e:  # pylint: disable=broad-except
+    except _GCS_ERRORS as e:
       logger.warning(
           'Error listing GCS directory %s: %r', dir_path, e, exc_info=True
       )
@@ -178,7 +202,7 @@ class GcsFileSystem(ProfileFileSystem):
           if blob.name.endswith('.xplane.pb')
           or blob.name.endswith('.xplane.riegeli')
       ]
-    except Exception as e:  # pylint: disable=broad-except
+    except _GCS_ERRORS as e:
       logger.warning(
           'Error listing GCS directory %s: %r', dir_path, e, exc_info=True
       )
@@ -192,7 +216,7 @@ class GcsFileSystem(ProfileFileSystem):
           or blob.name.endswith('.xplane.riegeli')
           for blob in blobs
       )
-    except Exception as e:  # pylint: disable=broad-except
+    except _GCS_ERRORS as e:
       logger.warning(
           'Error listing GCS directory %s: %r', dir_path, e, exc_info=True
       )
@@ -202,7 +226,7 @@ class GcsFileSystem(ProfileFileSystem):
     try:
       blobs, _, _ = _list_gcs_dir(self._storage_client, dir_path)
       return [os.path.basename(blob.name) for blob in blobs]
-    except Exception as e:  # pylint: disable=broad-except
+    except _GCS_ERRORS as e:
       logger.warning(
           'Error listing GCS directory %s: %r', dir_path, e, exc_info=True
       )
@@ -220,7 +244,7 @@ class GcsFileSystem(ProfileFileSystem):
           continue
         session_name = self._epath.Path(subdir_prefix).name
         path_by_session_name[session_name] = session_path_str
-    except Exception as e:  # pylint: disable=broad-except
+    except _GCS_ERRORS as e:
       logger.warning(
           'Error listing GCS directory %s: %r', dir_path, e, exc_info=True
       )

--- a/plugin/xprof/profile_io_test.py
+++ b/plugin/xprof/profile_io_test.py
@@ -294,9 +294,15 @@ class GcsFileSystemTest(absltest.TestCase):
     self.assertCountEqual(basenames, ['1.xplane.pb', '3.xplane.riegeli'])
 
   def test_get_xplane_basenames_exception(self):
-    """Checks exception handling in get_xplane_basenames."""
-    self.mock_client.list_blobs.side_effect = Exception('network error')
+    """Checks that expected GCS/OS errors degrade to an empty list."""
+    self.mock_client.list_blobs.side_effect = OSError('network error')
     self.assertEqual(self.fs.get_xplane_basenames('gs://bucket/path'), [])
+
+  def test_get_xplane_basenames_type_error_propagates(self):
+    """Programming errors from listing must not be swallowed."""
+    self.mock_client.list_blobs.side_effect = TypeError('bug in caller')
+    with self.assertRaises(TypeError):
+      self.fs.get_xplane_basenames('gs://bucket/path')
 
   def test_get_xplane_file_states_success(self):
     """Checks getting file states with md5 hash identification."""
@@ -324,9 +330,30 @@ class GcsFileSystemTest(absltest.TestCase):
     self.assertIsNone(self.fs.get_xplane_file_states('gs://bucket/path'))
 
   def test_get_xplane_file_states_exception(self):
-    """Checks Exception handling in get_xplane_file_states."""
-    self.mock_client.list_blobs.side_effect = Exception('network error')
+    """Checks that expected GCS/OS errors degrade to None."""
+    self.mock_client.list_blobs.side_effect = OSError('network error')
     self.assertIsNone(self.fs.get_xplane_file_states('gs://bucket/path'))
+
+  def test_gcs_errors_tuple_shape(self):
+    """_GCS_ERRORS always includes OSError/TimeoutError; never bare Exception."""
+    self.assertIn(OSError, profile_io._GCS_ERRORS)
+    self.assertIn(TimeoutError, profile_io._GCS_ERRORS)
+    self.assertNotIn(Exception, profile_io._GCS_ERRORS)
+    self.assertNotIn(TypeError, profile_io._GCS_ERRORS)
+    # GoogleAPICallError is included when the real GCS libs imported successfully.
+    self.assertTrue(
+        any(err.__name__ == 'GoogleAPICallError' for err in profile_io._GCS_ERRORS)
+        or all(
+            err in (OSError, TimeoutError, RuntimeError)
+            for err in profile_io._GCS_ERRORS
+        )
+    )
+
+  def test_get_xplane_file_states_type_error_propagates(self):
+    """Programming errors from listing must not be swallowed."""
+    self.mock_client.list_blobs.side_effect = TypeError('bug in caller')
+    with self.assertRaises(TypeError):
+      self.fs.get_xplane_file_states('gs://bucket/path')
 
   def test_dir_has_xplane_files(self):
     """Checks checking dir_has_xplane_files on GCS."""
@@ -341,8 +368,8 @@ class GcsFileSystemTest(absltest.TestCase):
     self.assertFalse(self.fs.dir_has_xplane_files('gs://bucket/path'))
 
   def test_dir_has_xplane_files_exception(self):
-    """Checks exception handling in dir_has_xplane_files."""
-    self.mock_client.list_blobs.side_effect = Exception('network error')
+    """Checks that TimeoutError degrades to False."""
+    self.mock_client.list_blobs.side_effect = TimeoutError('network error')
     self.assertFalse(self.fs.dir_has_xplane_files('gs://bucket/path'))
 
   def test_get_all_basenames(self):
@@ -356,8 +383,8 @@ class GcsFileSystemTest(absltest.TestCase):
     )
 
   def test_get_all_basenames_exception(self):
-    """Checks Exception handling in get_all_basenames."""
-    self.mock_client.list_blobs.side_effect = Exception('network error')
+    """Checks that OSError degrades to an empty list."""
+    self.mock_client.list_blobs.side_effect = OSError('network error')
     self.assertEqual(self.fs.get_all_basenames('gs://bucket/path'), [])
 
   def test_get_session_paths(self):
@@ -380,8 +407,8 @@ class GcsFileSystemTest(absltest.TestCase):
     self.assertEqual(paths, {})
 
   def test_get_session_paths_exception(self):
-    """Checks Exception handling in get_session_paths."""
-    self.mock_client.list_blobs.side_effect = Exception('network error')
+    """Checks that OSError degrades to an empty dict."""
+    self.mock_client.list_blobs.side_effect = OSError('network error')
     self.assertEqual(self.fs.get_session_paths('gs://bucket/path'), {})
 
   def test_read_json(self):


### PR DESCRIPTION
## Summary
- Replace broad `except Exception` in GcsFileSystem with a narrow GCS/OS error tuple
- Document mTLS/pyOpenSSL bypass rationale on get_storage_client
- Tests for error handling behavior

## Plan
FIX-003 / PR-C from critique fixes super plan.

## Test plan
- [x] profile_io_test.py