### PR TITLE
fix(convert): fail-fast if unified tools fail to register

### DIFF
--- a/xprof/convert/BUILD
+++ b/xprof/convert/BUILD
@@ -3017,13 +3017,31 @@ cc_library(
     srcs = ["unified_tools_registration.cc"],
     hdrs = ["unified_tools_registration.h"],
     deps = [
+        ":tool_options",
         ":unified_hlo_stats_processor",
         ":unified_memory_viewer_processor",
         ":unified_op_profile_processor",
         ":unified_overview_page_processor",
         ":unified_profile_processor_factory",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
     alwayslink = 1,
+)
+
+cc_test(
+    name = "unified_tools_registration_test",
+    srcs = ["unified_tools_registration_test.cc"],
+    deps = [
+        ":tool_options",
+        ":unified_profile_processor",
+        ":unified_profile_processor_factory",
+        ":unified_tools_registration",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+    ],
 )
 
 cc_library(

--- a/xprof/convert/unified_tools_registration.cc
+++ b/xprof/convert/unified_tools_registration.cc
@@ -15,6 +15,15 @@ limitations under the License.
 
 #include "xprof/convert/unified_tools_registration.h"
 
+#include <string>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "xprof/convert/tool_options.h"
 #include "xprof/convert/unified_hlo_stats_processor.h"
 #include "xprof/convert/unified_memory_viewer_processor.h"
 #include "xprof/convert/unified_op_profile_processor.h"
@@ -22,6 +31,17 @@ limitations under the License.
 #include "xprof/convert/unified_profile_processor_factory.h"
 
 namespace xprof {
+namespace {
+
+// Tools that must be available after RegisterUnifiedToolRegistrations().
+constexpr absl::string_view kExpectedUnifiedTools[] = {
+    "hlo_stats",
+    "memory_viewer",
+    "op_profile",
+    "overview_page",
+};
+
+}  // namespace
 
 void RegisterUnifiedToolRegistrations() {
   REGISTER_UNIFIED_PROFILE_PROCESSOR("hlo_stats", UnifiedHloStatsProcessor);
@@ -30,6 +50,29 @@ void RegisterUnifiedToolRegistrations() {
   REGISTER_UNIFIED_PROFILE_PROCESSOR("op_profile", UnifiedOpProfileProcessor);
   REGISTER_UNIFIED_PROFILE_PROCESSOR("overview_page",
                                      UnifiedOverviewPageProcessor);
+}
+
+absl::Status EnsureUnifiedToolsRegistered() {
+  RegisterUnifiedToolRegistrations();
+
+  tensorflow::profiler::ToolOptions options;
+  std::vector<std::string> missing_tools;
+  for (absl::string_view tool_name : kExpectedUnifiedTools) {
+    auto processor = UnifiedProfileProcessorFactory::GetInstance().Create(
+        tool_name, options);
+    if (processor == nullptr) {
+      missing_tools.emplace_back(tool_name);
+    }
+  }
+
+  if (!missing_tools.empty()) {
+    std::string message = absl::StrCat(
+        "Expected unified tools failed to register: ",
+        absl::StrJoin(missing_tools, ", "));
+    LOG(ERROR) << message;
+    return absl::FailedPreconditionError(message);
+  }
+  return absl::OkStatus();
 }
 
 }  // namespace xprof

--- a/xprof/convert/unified_tools_registration.h
+++ b/xprof/convert/unified_tools_registration.h
@@ -16,10 +16,17 @@ limitations under the License.
 #ifndef THIRD_PARTY_XPROF_CONVERT_UNIFIED_TOOLS_REGISTRATION_H_
 #define THIRD_PARTY_XPROF_CONVERT_UNIFIED_TOOLS_REGISTRATION_H_
 
+#include "absl/status/status.h"
+
 namespace xprof {
 // Registers unified profile processors for various profiling tools (e.g.,
 // hlo_stats, memory_viewer) with the processor factory.
 void RegisterUnifiedToolRegistrations();
-}
+
+// Registers unified tools and verifies that every expected tool can create a
+// processor. Returns FailedPrecondition if any expected tool is missing.
+// Expected tools: hlo_stats, memory_viewer, op_profile, overview_page.
+absl::Status EnsureUnifiedToolsRegistered();
+}  // namespace xprof
 
 #endif  // THIRD_PARTY_XPROF_CONVERT_UNIFIED_TOOLS_REGISTRATION_H_

--- a/xprof/convert/unified_tools_registration_test.cc
+++ b/xprof/convert/unified_tools_registration_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xprof/convert/unified_tools_registration.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "xprof/convert/tool_options.h"
+#include "xprof/convert/unified_profile_processor.h"
+#include "xprof/convert/unified_profile_processor_factory.h"
+
+namespace xprof {
+namespace {
+
+using ::tensorflow::profiler::ToolOptions;
+
+// Expected unified tools that EnsureUnifiedToolsRegistered must provide.
+constexpr absl::string_view kExpectedUnifiedTools[] = {
+    "hlo_stats",
+    "memory_viewer",
+    "op_profile",
+    "overview_page",
+};
+
+TEST(UnifiedToolsRegistrationTest, EnsureRegistersAllExpectedTools) {
+  absl::Status status = EnsureUnifiedToolsRegistered();
+  ASSERT_TRUE(status.ok()) << status;
+
+  ToolOptions options;
+  for (absl::string_view tool_name : kExpectedUnifiedTools) {
+    std::unique_ptr<UnifiedProfileProcessor> processor =
+        UnifiedProfileProcessorFactory::GetInstance().Create(tool_name,
+                                                             options);
+    EXPECT_NE(processor, nullptr)
+        << "Missing processor for tool: " << tool_name;
+  }
+}
+
+TEST(UnifiedToolsRegistrationTest, EnsureIsIdempotent) {
+  ASSERT_TRUE(EnsureUnifiedToolsRegistered().ok());
+  ASSERT_TRUE(EnsureUnifiedToolsRegistered().ok());
+
+  ToolOptions options;
+  for (absl::string_view tool_name : kExpectedUnifiedTools) {
+    EXPECT_NE(UnifiedProfileProcessorFactory::GetInstance().Create(tool_name,
+                                                                   options),
+              nullptr);
+  }
+}
+
+// Existing call sites that only Register must keep working.
+TEST(UnifiedToolsRegistrationTest, RegisterStillCreatesExpectedTools) {
+  RegisterUnifiedToolRegistrations();
+
+  ToolOptions options;
+  for (absl::string_view tool_name : kExpectedUnifiedTools) {
+    EXPECT_NE(UnifiedProfileProcessorFactory::GetInstance().Create(tool_name,
+                                                                   options),
+              nullptr)
+        << "Missing processor for tool: " << tool_name;
+  }
+}
+
+}  // namespace
+}  // namespace xprof

--- a/xprof/convert/xplane_to_tools_data_with_profile_processor.cc
+++ b/xprof/convert/xplane_to_tools_data_with_profile_processor.cc
@@ -194,7 +194,7 @@ absl::StatusOr<std::string> ConvertMultiXSpacesToToolDataWithProfileProcessor(
   absl::Time start_time = absl::Now();
 
   if (absl::GetFlag(FLAGS_enable_unified_xprof)) {
-    xprof::RegisterUnifiedToolRegistrations();
+    TF_RETURN_IF_ERROR(xprof::EnsureUnifiedToolsRegistered());
     auto unified_processor =
         xprof::UnifiedProfileProcessorFactory::GetInstance().Create(
             tool_name, options);


### PR DESCRIPTION
## Summary
- Adds `EnsureUnifiedToolsRegistered()` which calls `RegisterUnifiedToolRegistrations()` and verifies that the four expected unified tools (`hlo_stats`, `memory_viewer`, `op_profile`, `overview_page`) can create processors via `UnifiedProfileProcessorFactory`.
- On missing tools: `LOG(ERROR)` + `absl::FailedPreconditionError` (collects all missing names).
- Call site `ConvertMultiXSpacesToToolDataWithProfileProcessor` uses `TF_RETURN_IF_ERROR(EnsureUnifiedToolsRegistered())` when `--enable_unified_xprof` is on, so registration failures fail fast instead of silently falling back to legacy processors.
- Existing `RegisterUnifiedToolRegistrations()` call sites remain unchanged.
- Unit tests cover all four tool names after Ensure, idempotency, and Register-only behavior.

Fixes FIX-005 (unified tools fail-fast). FIX-025 golden asserts per processor deferred (optional / larger scope).

## Test plan
- [x] `bazel test //xprof/convert:unified_tools_registration_test` (PASSED: 3 tests)
- [x] `bazel build //xprof/convert:unified_tools_registration` (SUCCESS)
- [ ] Full convert suite / CI on PR

```
bazel test //xprof/convert:unified_tools_registration_test \
  --config=clang_local --macos_minimum_os=11.0 \
  --copt=-mmacosx-version-min=11.0 --copt=-faligned-allocation
```