### PR TITLE
fix(trace_viewer): centralize WASM string free conventions

### DIFF
--- a/frontend/app/components/trace_viewer_v2/BUILD
+++ b/frontend/app/components/trace_viewer_v2/BUILD
@@ -192,6 +192,14 @@ wasm_cc_binary(
 )
 
 ts_library(
+    name = "wasm_string_utils",
+    srcs = [
+        "wasm_string_utils.ts",
+    ],
+    visibility = ["//frontend:__subpackages__"],
+)
+
+ts_library(
     name = "app_bundle_ts",
     srcs = [
         "feature_flags.ts",
@@ -199,6 +207,7 @@ ts_library(
     ],
     visibility = ["//frontend:__subpackages__"],
     deps = [
+        ":wasm_string_utils",
         "@npm//@types/emscripten",
         "@npm//@webgpu/types",
     ],
@@ -210,9 +219,11 @@ ts_library(
     srcs = [
         "feature_flags_test.ts",
         "main_test.ts",
+        "wasm_string_utils_test.ts",
     ],
     deps = [
         ":app_bundle_ts",
+        ":wasm_string_utils",
         "//third_party/javascript/typings/jasmine",
         "@npm//@webgpu/types",
     ],

--- a/frontend/app/components/trace_viewer_v2/main.ts
+++ b/frontend/app/components/trace_viewer_v2/main.ts
@@ -1,5 +1,6 @@
 
 import {getDefaultFeatureFlag} from './feature_flags';
+import {withWasmHeapBuffer} from './wasm_string_utils';
 
 /**
  * The over-fetching factor for trace events.
@@ -181,7 +182,12 @@ declare global {
     normalizeTimestamps: boolean,
   ): void;
   getAllFlowCategories(): Array<{id: number; name: string}>;
-  setCompressedSearchResultsInWasm(data: Uint8Array): void;
+  /**
+   * Passes compressed protobuf search results from a WASM heap buffer.
+   * Caller owns `dataPtr` and must free it after this returns
+   * (use `withWasmHeapBuffer` from wasm_string_utils.ts).
+   */
+  setCompressedSearchResultsInWasm(dataPtr: number, dataSize: number): void;
   setSearchResultsInWasm(data: TraceData): void;
   loadTraceData?(url: string): Promise<void>;
   loadSearchResults?(url: string): Promise<void>;
@@ -524,29 +530,21 @@ function processPerfettoTrace(
   data: Uint8Array,
   traceviewerModule: TraceViewerV2Module,
 ) {
-  let dataPtr: number | undefined;
   try {
-    dataPtr = traceviewerModule._malloc(data.length);
-    if (!dataPtr) {
-      throw new Error('Failed to allocate WASM memory buffer');
-    }
-    traceviewerModule.HEAPU8.set(data, dataPtr);
-
-    traceviewerModule.processPerfettoTraceEvents(
-      dataPtr,
-      data.length,
-      undefined,
-      true,
-    );
+    // Heap buffer is freed even if processPerfettoTraceEvents throws.
+    withWasmHeapBuffer(traceviewerModule, data, (dataPtr, dataSize) => {
+      traceviewerModule.processPerfettoTraceEvents(
+        dataPtr,
+        dataSize,
+        undefined,
+        true,
+      );
+    });
   } catch (error) {
     dispatchErrorStatus(
       error instanceof Error ? error.message : String(error),
       error,
     );
-  } finally {
-    if (dataPtr !== undefined && dataPtr !== 0) {
-      traceviewerModule._free(dataPtr);
-    }
   }
 }
 
@@ -820,23 +818,17 @@ async function fetchAndProcessTraceData({
 
       performance.mark('traceProcessStart');
 
-      let dataPtr: number | undefined;
-      try {
-        dataPtr = traceviewerModule._malloc(buffer.byteLength);
-        if (!dataPtr) {
-          throw new Error('Failed to allocate WASM memory buffer');
-        }
-        traceviewerModule.HEAPU8.set(new Uint8Array(buffer), dataPtr);
-        traceviewerModule.processCompressedTraceEvents(
-          dataPtr,
-          buffer.byteLength,
-          timeRange,
-        );
-      } finally {
-        if (dataPtr !== undefined && dataPtr !== 0) {
-          traceviewerModule._free(dataPtr);
-        }
-      }
+      withWasmHeapBuffer(
+        traceviewerModule,
+        new Uint8Array(buffer),
+        (dataPtr, dataSize) => {
+          traceviewerModule.processCompressedTraceEvents(
+            dataPtr,
+            dataSize,
+            timeRange,
+          );
+        },
+      );
     } else {
       const jsonData = await loadJsonDataInternal(urlObj.toString());
       if (isAbortRequested()) return;
@@ -1106,8 +1098,17 @@ export async function traceViewerV2Main(
 
       if (urlObj.pathname.endsWith('.pb')) {
         const buffer = await loadCompressedTraceDataInternal(urlObj.toString());
-        traceviewerModule.setCompressedSearchResultsInWasm(
+        // Pointer+size transfer mirrors processCompressedTraceEvents and
+        // guarantees free-on-return via withWasmHeapBuffer.
+        withWasmHeapBuffer(
+          traceviewerModule,
           new Uint8Array(buffer),
+          (dataPtr, dataSize) => {
+            traceviewerModule.setCompressedSearchResultsInWasm(
+              dataPtr,
+              dataSize,
+            );
+          },
         );
       } else {
         const jsonData = (await loadJsonDataInternal(

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_pb_event_parser.cc
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_pb_event_parser.cc
@@ -116,11 +116,24 @@ void ParseAndProcessCompressedTraceEvents(
                                        Application::Instance().timeline());
 }
 
+void SetCompressedSearchResultsInWasm(uintptr_t data_ptr, size_t data_size) {
+  if (!Application::Instance().IsInitialized()) {
+    return;
+  }
+  // Ownership of data_ptr remains with the JS caller (see wasm_string_utils.ts).
+  const ParsedTraceEvents parsed_events =
+      ParseCompressedTraceEvents(data_ptr, data_size, emscripten::val::null());
+  Application::Instance().timeline().SetSearchResults(parsed_events);
+  Application::Instance().RequestRedraw();
+}
+
 EMSCRIPTEN_BINDINGS(trace_pb_event_parser) {
   emscripten::function(
       "processCompressedTraceEvents",
       static_cast<void (*)(uintptr_t, size_t, const emscripten::val&)>(
           &traceviewer::ParseAndProcessCompressedTraceEvents));
+  emscripten::function("setCompressedSearchResultsInWasm",
+                       &traceviewer::SetCompressedSearchResultsInWasm);
 }
 
 }  // namespace traceviewer

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_pb_event_parser.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_pb_event_parser.h
@@ -14,6 +14,10 @@ class Timeline;
 // Parses compressed trace data and updates the timeline in the Application
 // instance. This is the main entry point for processing compressed trace data
 // from the frontend.
+//
+// Ownership: `data_ptr` is a WASM heap pointer allocated by JS (`_malloc`).
+// The callee only reads the buffer; the JS caller must free it after return
+// (see `withWasmHeapBuffer` in wasm_string_utils.ts).
 void ParseAndProcessCompressedTraceEvents(
     uintptr_t data_ptr, size_t data_size,
     const emscripten::val& visible_range_from_url);
@@ -25,6 +29,13 @@ void ParseAndProcessCompressedTraceEvents(
     uintptr_t data_ptr, size_t data_size,
     const emscripten::val& visible_range_from_url, DataProvider& data_provider,
     Timeline& timeline);
+
+// Parses compressed protobuf search results from a WASM heap buffer and
+// updates the timeline search state.
+//
+// Ownership: same as ParseAndProcessCompressedTraceEvents — JS allocates with
+// `_malloc` and must `_free` after the call returns.
+void SetCompressedSearchResultsInWasm(uintptr_t data_ptr, size_t data_size);
 
 }  // namespace traceviewer
 

--- a/frontend/app/components/trace_viewer_v2/wasm_string_utils.ts
+++ b/frontend/app/components/trace_viewer_v2/wasm_string_utils.ts
@@ -1,0 +1,117 @@
+/**
+ * WASM heap ownership helpers for Trace Viewer v2.
+ *
+ * ## Free conventions
+ *
+ * 1. **Raw `_malloc` ownership (this file):** Any pointer obtained via
+ *    `module._malloc` MUST be released with `module._free` after the native
+ *    call returns. Prefer `withWasmHeapBuffer` / `withWasmCString` so free is
+ *    guaranteed even if the callback throws. Never free a null/0 pointer.
+ *
+ * 2. **Embind / `emscripten::val` transfers:** JS strings and objects passed
+ *    through embind (e.g. `setSearchResultsInWasm(traceData)`) are owned by the
+ *    JavaScript GC. Do **not** call `_free` on values returned from embind
+ *    string getters unless the C++ binding documentation explicitly says the
+ *    pointer was allocated with `malloc` for JS to free.
+ *
+ * 3. **Search result transfer:** Prefer pointer+size heap transfers for large
+ *    binary/protobuf payloads (`setCompressedSearchResultsInWasm`,
+ *    `processCompressedTraceEvents`, `processPerfettoTraceEvents`) using
+ *    `withWasmHeapBuffer`. JSON search results may continue to use embind.
+ *
+ * These helpers exist so new call sites do not reintroduce the #2753-class
+ * leaks fixed for binary buffer transfers.
+ */
+
+/** Minimal module surface required for heap allocate/free. */
+export interface WasmHeapModule {
+  HEAPU8: Uint8Array;
+  _malloc(size: number): number;
+  _free(ptr: number): void;
+}
+
+/**
+ * Null-safe free for a WASM heap pointer obtained via `_malloc`.
+ * No-ops for undefined, null, or 0.
+ */
+export function freeWasmPtr(
+  module: WasmHeapModule,
+  ptr: number | null | undefined,
+): void {
+  if (ptr !== undefined && ptr !== null && ptr !== 0) {
+    module._free(ptr);
+  }
+}
+
+/**
+ * Allocates `byteLength` bytes on the WASM heap, invokes `fn(ptr)`, and always
+ * frees the pointer afterward (including when `fn` throws).
+ *
+ * Prefer `withWasmHeapBuffer` when the allocation is immediately filled from
+ * a typed array.
+ */
+export function withWasmMalloc<T>(
+  module: WasmHeapModule,
+  byteLength: number,
+  fn: (ptr: number) => T,
+): T {
+  if (byteLength < 0) {
+    throw new Error('withWasmMalloc: byteLength must be non-negative');
+  }
+  // Zero-length allocations are valid but need no heap traffic.
+  if (byteLength === 0) {
+    return fn(0);
+  }
+  const ptr = module._malloc(byteLength);
+  if (!ptr) {
+    throw new Error('Failed to allocate WASM memory buffer');
+  }
+  try {
+    return fn(ptr);
+  } finally {
+    freeWasmPtr(module, ptr);
+  }
+}
+
+/**
+ * Copies `data` into a freshly malloc'd WASM heap buffer, calls
+ * `fn(ptr, byteLength)`, then always frees the buffer.
+ *
+ * Use this for binary transfers into exported C/C++ entry points that accept
+ * `(dataPtr, dataSize)` (compressed traces, Perfetto, compressed search).
+ */
+export function withWasmHeapBuffer<T>(
+  module: WasmHeapModule,
+  data: Uint8Array | ArrayBuffer,
+  fn: (ptr: number, byteLength: number) => T,
+): T {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  return withWasmMalloc(module, bytes.byteLength, (ptr) => {
+    if (bytes.byteLength > 0) {
+      module.HEAPU8.set(bytes, ptr);
+    }
+    return fn(ptr, bytes.byteLength);
+  });
+}
+
+/**
+ * Encodes `jsString` as a null-terminated UTF-8 C string on the WASM heap,
+ * invokes `fn(ptr)`, and always frees the allocation.
+ *
+ * Prefer embind for ordinary string arguments. Use this only when calling a
+ * raw C API that expects `const char*`.
+ */
+export function withWasmCString<T>(
+  module: WasmHeapModule,
+  jsString: string,
+  fn: (ptr: number) => T,
+): T {
+  // TextEncoder does not emit a trailing NUL; allocate one extra byte.
+  const encoded = new TextEncoder().encode(jsString);
+  const byteLength = encoded.length + 1;
+  return withWasmMalloc(module, byteLength, (ptr) => {
+    module.HEAPU8.set(encoded, ptr);
+    module.HEAPU8[ptr + encoded.length] = 0;
+    return fn(ptr);
+  });
+}

--- a/frontend/app/components/trace_viewer_v2/wasm_string_utils_test.ts
+++ b/frontend/app/components/trace_viewer_v2/wasm_string_utils_test.ts
@@ -1,0 +1,153 @@
+import {
+  freeWasmPtr,
+  WasmHeapModule,
+  withWasmCString,
+  withWasmHeapBuffer,
+  withWasmMalloc,
+} from './wasm_string_utils';
+
+interface MockWasmModule extends WasmHeapModule {
+  freeCount: number;
+  lastFreedPtr: number | null;
+}
+
+/**
+ * Lightweight mock of the Emscripten heap surface used by wasm_string_utils.
+ * Tracks free invocations so tests can assert leak-free ownership.
+ */
+function createMockModule(options?: {
+  failMalloc?: boolean;
+  heapSize?: number;
+}): MockWasmModule {
+  const heapSize = options?.heapSize ?? 4096;
+  const heap = new Uint8Array(heapSize);
+  let nextPtr = 64;
+  const mock: MockWasmModule = {
+    HEAPU8: heap,
+    freeCount: 0,
+    lastFreedPtr: null,
+    _malloc(size: number): number {
+      if (options?.failMalloc) {
+        return 0;
+      }
+      const ptr = nextPtr;
+      nextPtr += size + 8;
+      if (nextPtr > heapSize) {
+        throw new Error('mock heap exhausted');
+      }
+      return ptr;
+    },
+    _free(ptr: number): void {
+      mock.freeCount += 1;
+      mock.lastFreedPtr = ptr;
+    },
+  };
+  return mock;
+}
+
+describe('wasm_string_utils', () => {
+  describe('freeWasmPtr', () => {
+    it('no-ops for null, undefined, and 0', () => {
+      const module = createMockModule();
+      freeWasmPtr(module, null);
+      freeWasmPtr(module, undefined);
+      freeWasmPtr(module, 0);
+      expect(module.freeCount).toBe(0);
+    });
+
+    it('frees non-zero pointers', () => {
+      const module = createMockModule();
+      freeWasmPtr(module, 42);
+      expect(module.freeCount).toBe(1);
+      expect(module.lastFreedPtr).toBe(42);
+    });
+  });
+
+  describe('withWasmMalloc', () => {
+    it('frees after a successful callback', () => {
+      const module = createMockModule();
+      const result = withWasmMalloc(module, 16, (ptr) => {
+        expect(ptr).toBeGreaterThan(0);
+        return 'ok';
+      });
+      expect(result).toBe('ok');
+      expect(module.freeCount).toBe(1);
+    });
+
+    it('frees even when the callback throws', () => {
+      const module = createMockModule();
+      expect(() =>
+        withWasmMalloc(module, 16, () => {
+          throw new Error('callback boom');
+        }),
+      ).toThrowError('callback boom');
+      expect(module.freeCount).toBe(1);
+    });
+
+    it('does not call free when malloc fails', () => {
+      const module = createMockModule({failMalloc: true});
+      expect(() => withWasmMalloc(module, 16, () => 'x')).toThrowError(
+        /Failed to allocate WASM memory buffer/,
+      );
+      expect(module.freeCount).toBe(0);
+    });
+
+    it('skips malloc/free for zero-length allocations', () => {
+      const module = createMockModule();
+      const result = withWasmMalloc(module, 0, (ptr) => {
+        expect(ptr).toBe(0);
+        return 123;
+      });
+      expect(result).toBe(123);
+      expect(module.freeCount).toBe(0);
+    });
+  });
+
+  describe('withWasmHeapBuffer', () => {
+    it('copies bytes and always frees', () => {
+      const module = createMockModule();
+      const data = new Uint8Array([1, 2, 3, 4]);
+      const seen: number[] = [];
+      withWasmHeapBuffer(module, data, (ptr, size) => {
+        expect(size).toBe(4);
+        for (let i = 0; i < size; i++) {
+          seen.push(module.HEAPU8[ptr + i]);
+        }
+      });
+      expect(seen).toEqual([1, 2, 3, 4]);
+      expect(module.freeCount).toBe(1);
+    });
+
+    it('frees when the native-style callback throws', () => {
+      const module = createMockModule();
+      expect(() =>
+        withWasmHeapBuffer(module, new Uint8Array([9]), () => {
+          throw new Error('native failed');
+        }),
+      ).toThrowError('native failed');
+      expect(module.freeCount).toBe(1);
+    });
+  });
+
+  describe('withWasmCString', () => {
+    it('writes a null-terminated UTF-8 string and frees', () => {
+      const module = createMockModule();
+      withWasmCString(module, 'hi', (ptr) => {
+        expect(module.HEAPU8[ptr]).toBe('h'.charCodeAt(0));
+        expect(module.HEAPU8[ptr + 1]).toBe('i'.charCodeAt(0));
+        expect(module.HEAPU8[ptr + 2]).toBe(0);
+      });
+      expect(module.freeCount).toBe(1);
+    });
+
+    it('frees when the callback throws', () => {
+      const module = createMockModule();
+      expect(() =>
+        withWasmCString(module, 'leak-me', () => {
+          throw new Error('cstr boom');
+        }),
+      ).toThrowError('cstr boom');
+      expect(module.freeCount).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Centralizes WASM heap ownership conventions for Trace Viewer v2 to reduce leak risk on binary/string transfers (FIX-002 / post-#2753, #2947).

- Adds documented helpers in `wasm_string_utils.ts`:
  - `withWasmHeapBuffer` / `withWasmMalloc` / `withWasmCString` (always free, including on throw)
  - `freeWasmPtr` (null-safe)
- Refactors high-risk call sites in `main.ts` to use `withWasmHeapBuffer`:
  - Perfetto trace upload path
  - Compressed `.pb` trace load path
  - Compressed search-results load path (priority)
- Implements missing `setCompressedSearchResultsInWasm` embind binding as **ptr+size** (matching `processCompressedTraceEvents` ownership from #2753)
- Unit tests assert free is invoked even when the callback throws

FIX-036 (search "i of N" formatter) intentionally skipped to keep this PR focused on WASM lifetime.

## Test plan
- [x] Node smoke test of `wasm_string_utils` free-on-throw / no-free-on-malloc-fail / C-string NUL termination
- [ ] `bazel test //frontend/app/components/trace_viewer_v2:tests` (jasmine; when google3/jasmine harness available)
- [ ] Manual: load compressed `.pb` trace and run search returning `.pb` results; confirm no progressive WASM heap growth across repeated searches
- [ ] Manual: Perfetto file upload still renders and does not leak on error paths