### PR TITLE
feat(convert): flag-gated CustomCall duty-cycle modes (default legacy)

### DIFF
--- a/docs/overview_page.md
+++ b/docs/overview_page.md
@@ -22,7 +22,17 @@ of both variations:
   - **Average Step Time (training only)**: The step time averaged over all steps
     sampled.
   - **FLOPS Utilization**
-  - **TPU Duty Cycle**
+  - **TPU Duty Cycle**: Fraction of profiled module time that device ops are
+    considered "on-duty" (busy). By default (post-#2942), only standard
+    off-duty HLO categories (infeed, outfeed, host send/recv, async-done,
+    megacore fusion self-time) are idle; **CustomCall is not special-cased**.
+    Opt-in CustomCall semantics via env var
+    `XPROF_CUSTOM_CALL_DUTY_CYCLE_MODE`:
+    - `legacy` (default): IsOffDutyOp categories only.
+    - `flops_model`: CustomCall is off-duty only when both `flops` and
+      `model_flops` are zero/absent (Pallas-style cost metadata).
+    - `ici_aware`: same as `flops_model`, but CustomCall with `uses_ici != 0`
+      is forced on-duty (collective custom-calls).
   - **Memory Bandwidth Utilization**
   - **Program Goodput Efficiency**: Measures how your model is performing
     relative to ideal performance on this hardware.

--- a/xprof/convert/BUILD
+++ b/xprof/convert/BUILD
@@ -1361,6 +1361,7 @@ cc_library(
         "@xla//xla/tsl/profiler/utils:xplane_builder",
         "@xla//xla/tsl/profiler/utils:xplane_schema",
         "@xla//xla/tsl/profiler/utils:xplane_utils",
+        "@xla//xla/tsl/profiler/utils:xplane_visitor",
         "@xla//xla/tsl/util:stats_calculator_portable",
     ],
 )
@@ -1414,6 +1415,7 @@ cc_test(
         "@org_xprof//xprof/utils:hlo_proto_map",
         "@org_xprof//xprof/utils:op_metrics_db_utils",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+        "@xla//xla/hlo/ir:hlo",
         "@xla//xla/tsl/platform:status",
         "@xla//xla/tsl/platform:types",
         "@xla//xla/tsl/profiler/convert:xla_op_utils",

--- a/xprof/convert/xplane_to_op_stats.cc
+++ b/xprof/convert/xplane_to_op_stats.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -377,17 +378,110 @@ void UpdateFlatOpMetricsDbFromHloModuleMap(FlatOpMetricsDb& op_metrics_db,
   combiner.Combine(children_db);
 }
 
-DutyCycleTracker ConstructDutyCycleTracker(XPlaneVisitor& visitor) {
+CustomCallDutyCycleMode ParseCustomCallDutyCycleMode(absl::string_view mode) {
+  if (mode == "flops_model") {
+    return CustomCallDutyCycleMode::kFlopsModel;
+  }
+  if (mode == "ici_aware") {
+    return CustomCallDutyCycleMode::kIciAware;
+  }
+  // "legacy", empty, and any unknown value preserve post-#2942 defaults.
+  return CustomCallDutyCycleMode::kLegacy;
+}
+
+CustomCallDutyCycleMode GetCustomCallDutyCycleModeFromEnv() {
+  const char* env = std::getenv("XPROF_CUSTOM_CALL_DUTY_CYCLE_MODE");
+  if (env == nullptr) {
+    return CustomCallDutyCycleMode::kLegacy;
+  }
+  return ParseCustomCallDutyCycleMode(env);
+}
+
+namespace {
+
+// Returns true when a CustomCall event should be treated as off-duty under the
+// given non-legacy mode. Always returns false for kLegacy (caller should not
+// invoke this for the default path). Ported from commits 48cc8012 / f47b48c5.
+bool IsCustomCallOffDuty(
+    const std::optional<XStatVisitor>& hlo_category_stat,
+    const std::optional<XStatVisitor>& flops_stat,
+    const std::optional<XStatVisitor>& model_flops_stat,
+    const std::optional<XStatVisitor>& uses_ici_stat,
+    CustomCallDutyCycleMode mode) {
+  if (mode == CustomCallDutyCycleMode::kLegacy) {
+    return false;
+  }
+  // Custom-call check.
+  if (!hlo_category_stat.has_value() ||
+      hlo_category_stat->StrOrRefValue() !=
+          xla::HloOpcodeString(xla::HloOpcode::kCustomCall)) {
+    return false;
+  }
+  // ICI-aware: if it uses ICI, it is on-duty.
+  if (mode == CustomCallDutyCycleMode::kIciAware &&
+      uses_ici_stat.has_value() && uses_ici_stat->IntOrUintValue() != 0) {
+    return false;
+  }
+  // If metadata contains flop count (user-provided cost for Pallas),
+  // a count of 0 implies off-duty.
+  // If no flops stat is available, consider it as an off-duty op.
+  int64_t flops = flops_stat.has_value() ? flops_stat->IntOrUintValue() : 0;
+  int64_t model_flops =
+      model_flops_stat.has_value() ? model_flops_stat->IntOrUintValue() : 0;
+  return flops == 0 && model_flops == 0;
+}
+
+// Prefer metadata-level stats, then event-level (see c1723cbd / 48cc8012).
+std::optional<XStatVisitor> GetEventOrMetadataStat(const XEventVisitor& event,
+                                                   StatType stat_type) {
+  std::optional<XStatVisitor> stat = event.Metadata().GetStat(stat_type);
+  if (!stat) {
+    stat = event.GetStat(stat_type);
+  }
+  return stat;
+}
+
+}  // namespace
+
+DutyCycleTracker ConstructDutyCycleTracker(
+    XPlaneVisitor& visitor,
+    std::optional<CustomCallDutyCycleMode> mode_override) {
+  const CustomCallDutyCycleMode mode =
+      mode_override.value_or(GetCustomCallDutyCycleModeFromEnv());
   DutyCycleTracker duty_cycle_tracker;
   visitor.ForEachLine([&](const XLineVisitor& line) {
     if (line.Name() == tsl::profiler::kXlaOpLineName) {
       line.ForEachEvent([&](const XEventVisitor& event) {
+        // kLegacy path is intentionally bit-identical to post-#2942:
+        // only Metadata hlo_category + IsOffDutyOp (no flops/model_flops/ICI).
+        if (mode == CustomCallDutyCycleMode::kLegacy) {
+          auto hlo_category_stat =
+              event.Metadata().GetStat(StatType::kHloCategory);
+          duty_cycle_tracker.AddInterval(
+              event.GetTimespan(),
+              !(hlo_category_stat &&
+                tsl::profiler::IsOffDutyOp(
+                    hlo_category_stat->StrOrRefValue())));
+          return;
+        }
+
         auto hlo_category_stat =
-            event.Metadata().GetStat(StatType::kHloCategory);
+            GetEventOrMetadataStat(event, StatType::kHloCategory);
+        std::optional<XStatVisitor> flops_stat =
+            GetEventOrMetadataStat(event, StatType::kFlops);
+        std::optional<XStatVisitor> model_flops_stat =
+            GetEventOrMetadataStat(event, StatType::kModelFlops);
+        std::optional<XStatVisitor> uses_ici_stat;
+        if (mode == CustomCallDutyCycleMode::kIciAware) {
+          uses_ici_stat = GetEventOrMetadataStat(event, StatType::kUsesIci);
+        }
+
         duty_cycle_tracker.AddInterval(
             event.GetTimespan(),
             !(hlo_category_stat &&
-              tsl::profiler::IsOffDutyOp(hlo_category_stat->StrOrRefValue())));
+              (tsl::profiler::IsOffDutyOp(hlo_category_stat->StrOrRefValue()) ||
+               IsCustomCallOffDuty(hlo_category_stat, flops_stat,
+                                   model_flops_stat, uses_ici_stat, mode))));
       });
     } else if (line.Name() == tsl::profiler::kSparseCoreOpLineName) {
       line.ForEachEvent([&](const XEventVisitor& event) {

--- a/xprof/convert/xplane_to_op_stats.h
+++ b/xprof/convert/xplane_to_op_stats.h
@@ -16,10 +16,13 @@ limitations under the License.
 #ifndef XPROF_CONVERT_XPLANE_TO_OP_STATS_H_
 #define XPROF_CONVERT_XPLANE_TO_OP_STATS_H_
 
+#include <optional>
 #include <vector>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
+#include "xla/tsl/profiler/utils/xplane_visitor.h"
 #include "xprof/convert/duty_cycle_tracker.h"
 #include "plugin/xprof/protobuf/flat_op_metrics.pb.h"
 #include "plugin/xprof/protobuf/op_stats.pb.h"
@@ -28,12 +31,30 @@ limitations under the License.
 namespace tensorflow {
 namespace profiler {
 
+using ::tsl::profiler::XPlaneVisitor;
+
 struct OpStatsOptions {
   bool maybe_drop_incomplete_steps = false;
   bool generate_op_metrics_db = false;
   bool generate_step_db = false;
   bool generate_kernel_stats_db = false;
 };
+
+// How CustomCall ops contribute to TPU duty-cycle / chip utilization.
+// Default is kLegacy (post-#2942): only IsOffDutyOp categories are off-duty;
+// CustomCall is not special-cased.
+enum class CustomCallDutyCycleMode {
+  kLegacy = 0,      // IsOffDutyOp only (default; env: "legacy")
+  kFlopsModel = 1,  // CustomCall off-duty iff flops==0 && model_flops==0
+  kIciAware = 2,    // flops_model + force on-duty when uses_ici != 0
+};
+
+// Parses a mode name. Empty / unknown values map to kLegacy.
+// Recognized: "legacy", "flops_model", "ici_aware".
+CustomCallDutyCycleMode ParseCustomCallDutyCycleMode(absl::string_view mode);
+
+// Reads XPROF_CUSTOM_CALL_DUTY_CYCLE_MODE (unset/empty/unknown -> kLegacy).
+CustomCallDutyCycleMode GetCustomCallDutyCycleModeFromEnv();
 
 // Converts XSpace to FlatOpMetricsDb.
 absl::StatusOr<OpStats> ConvertXSpaceToFlatOpMetricsDb(
@@ -62,7 +83,11 @@ PerfEnv MakePerfEnv(double peak_tera_flops_per_second,
 PerfEnv GetPerfEnvFromXPlane(const XPlane& device_plane);
 
 // Constructs a DutyCycleTracker from the given XPlaneVisitor.
-DutyCycleTracker ConstructDutyCycleTracker(XPlaneVisitor& visitor);
+// When mode_override is nullopt, uses GetCustomCallDutyCycleModeFromEnv().
+// Default env mode is kLegacy (bit-identical to post-#2942 ConstructDutyCycleTracker).
+DutyCycleTracker ConstructDutyCycleTracker(
+    XPlaneVisitor& visitor,
+    std::optional<CustomCallDutyCycleMode> mode_override = std::nullopt);
 
 }  // namespace profiler
 }  // namespace tensorflow

--- a/xprof/convert/xplane_to_op_stats_test.cc
+++ b/xprof/convert/xplane_to_op_stats_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xprof/convert/xplane_to_op_stats.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <utility>
@@ -25,6 +26,7 @@ limitations under the License.
 #include "<gtest/gtest.h>"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/tsl/profiler/convert/xla_op_utils.h"
 #include "xla/tsl/profiler/utils/math_utils.h"
 #include "xla/tsl/profiler/utils/tf_xplane_visitor.h"
@@ -713,7 +715,29 @@ TEST(ConvertXPlaneToOpStats, ConstructDutyCycleTrackerFromSparseCore) {
   EXPECT_EQ(tracker.GetIdleTimePs(), 10);
 }
 
-TEST(ConvertXPlaneToOpStats, DISABLED_ConstructDutyCycleTrackerFromCustomCall) {
+TEST(ConvertXPlaneToOpStats, ParseCustomCallDutyCycleMode) {
+  struct Case {
+    absl::string_view input;
+    CustomCallDutyCycleMode expected;
+  };
+  const Case kCases[] = {
+      {"", CustomCallDutyCycleMode::kLegacy},
+      {"legacy", CustomCallDutyCycleMode::kLegacy},
+      {"flops_model", CustomCallDutyCycleMode::kFlopsModel},
+      {"ici_aware", CustomCallDutyCycleMode::kIciAware},
+      {"unknown", CustomCallDutyCycleMode::kLegacy},
+      {"FLOPS_MODEL", CustomCallDutyCycleMode::kLegacy},  // case-sensitive
+  };
+  for (const auto& c : kCases) {
+    EXPECT_EQ(ParseCustomCallDutyCycleMode(c.input), c.expected)
+        << "input=" << c.input;
+  }
+}
+
+// CustomCall flops scenarios (stats on the event, not metadata).
+// Module covers [5, 55) = 50ps.
+// Events: flops=0 [10,20), flops>0 [20,30), no flops stat [30,40).
+TEST(ConvertXPlaneToOpStats, ConstructDutyCycleTrackerFromCustomCallModes) {
   XSpace space;
   XPlane* device_plane = GetOrCreateTpuXPlane(
       &space, /*device_ordinal=*/0, /*device_type=*/"TPU v4",
@@ -723,23 +747,18 @@ TEST(ConvertXPlaneToOpStats, DISABLED_ConstructDutyCycleTrackerFromCustomCall) {
   XLineBuilder op_line = device_plane_builder.GetOrCreateLine(0);
   op_line.SetName(kXlaOpLineName);
 
-  // CustomCall with flops = 0 -> off duty
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_0_flops",
                /*offset_ps=*/10,
                /*duration_ps=*/10,
                {{StatType::kHloCategory,
                  xla::HloOpcodeString(xla::HloOpcode::kCustomCall)},
                 {StatType::kFlops, int64_t{0}}});
-
-  // CustomCall with flops > 0 -> on duty
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_with_flops",
                /*offset_ps=*/20,
                /*duration_ps=*/10,
                {{StatType::kHloCategory,
                  xla::HloOpcodeString(xla::HloOpcode::kCustomCall)},
                 {StatType::kFlops, int64_t{5}}});
-
-  // CustomCall without flops stat -> off duty
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_no_flops",
                /*offset_ps=*/30,
                /*duration_ps=*/10,
@@ -753,16 +772,31 @@ TEST(ConvertXPlaneToOpStats, DISABLED_ConstructDutyCycleTrackerFromCustomCall) {
                /*duration_ps=*/50);
 
   XPlaneVisitor visitor = tsl::profiler::CreateTfXPlaneVisitor(device_plane);
-  DutyCycleTracker tracker = ConstructDutyCycleTracker(visitor);
 
-  // active time is op 2 (10ps)
-  EXPECT_EQ(tracker.GetActiveTimePs(), 10);
-  // idle time is 50ps (module) - 10ps (active) = 40ps
-  EXPECT_EQ(tracker.GetIdleTimePs(), 40);
+  struct ModeCase {
+    CustomCallDutyCycleMode mode;
+    int64_t expected_active_ps;
+    int64_t expected_idle_ps;
+    const char* name;
+  };
+  // kLegacy only reads Metadata hlo_category (stats are on the event), so all
+  // three CustomCalls count as on-duty: active=30, idle=20.
+  // kFlopsModel / kIciAware: only flops>0 is on-duty: active=10, idle=40.
+  const ModeCase kCases[] = {
+      {CustomCallDutyCycleMode::kLegacy, 30, 20, "legacy"},
+      {CustomCallDutyCycleMode::kFlopsModel, 10, 40, "flops_model"},
+      {CustomCallDutyCycleMode::kIciAware, 10, 40, "ici_aware"},
+  };
+  for (const auto& c : kCases) {
+    DutyCycleTracker tracker = ConstructDutyCycleTracker(visitor, c.mode);
+    EXPECT_EQ(tracker.GetActiveTimePs(), c.expected_active_ps) << c.name;
+    EXPECT_EQ(tracker.GetIdleTimePs(), c.expected_idle_ps) << c.name;
+  }
 }
 
+// ICI + flops/model_flops CustomCall scenarios. Module covers [5, 95) = 90ps.
 TEST(ConvertXPlaneToOpStats,
-     DISABLED_ConstructDutyCycleTrackerFromCustomCallWithIci) {
+     ConstructDutyCycleTrackerFromCustomCallWithIciModes) {
   XSpace space;
   XPlane* device_plane = GetOrCreateTpuXPlane(
       &space, /*device_ordinal=*/0, /*device_type=*/"TPU v4",
@@ -772,7 +806,7 @@ TEST(ConvertXPlaneToOpStats,
   XLineBuilder op_line = device_plane_builder.GetOrCreateLine(0);
   op_line.SetName(kXlaOpLineName);
 
-  // CustomCall with uses_ici stat = 1 -> on duty (offset 10-20)
+  // CustomCall with uses_ici = 1 -> on duty under kIciAware (offset 10-20)
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_with_ici",
                /*offset_ps=*/10,
                /*duration_ps=*/10,
@@ -780,8 +814,7 @@ TEST(ConvertXPlaneToOpStats,
                  xla::HloOpcodeString(xla::HloOpcode::kCustomCall)},
                 {StatType::kUsesIci, int64_t{1}}});
 
-  // CustomCall with uses_ici = 0, no flops, no model flops -> off duty (offset
-  // 20-30)
+  // CustomCall with uses_ici = 0, no flops -> off duty under non-legacy
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_no_ici_no_flops",
                /*offset_ps=*/20,
                /*duration_ps=*/10,
@@ -789,7 +822,7 @@ TEST(ConvertXPlaneToOpStats,
                  xla::HloOpcodeString(xla::HloOpcode::kCustomCall)},
                 {StatType::kUsesIci, int64_t{0}}});
 
-  // CustomCall with uses_ici = 1, with flops -> on duty (offset 30-40)
+  // CustomCall with uses_ici = 1 and flops -> on duty (offset 30-40)
   CreateXEvent(&device_plane_builder, &op_line,
                "custom_call_with_ici_and_flops",
                /*offset_ps=*/30,
@@ -799,15 +832,14 @@ TEST(ConvertXPlaneToOpStats,
                 {StatType::kUsesIci, int64_t{1}},
                 {StatType::kFlops, int64_t{5}}});
 
-  // Regular CustomCall, no ici, no flops -> off duty (offset 40-50)
+  // Regular CustomCall, no ici, no flops -> off duty under non-legacy
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_no_ici",
                /*offset_ps=*/40,
                /*duration_ps=*/10,
                {{StatType::kHloCategory,
                  xla::HloOpcodeString(xla::HloOpcode::kCustomCall)}});
 
-  // CustomCall with uses_ici = 0, but with model_flops -> on duty (offset
-  // 50-60)
+  // CustomCall with model_flops -> on duty (offset 50-60)
   CreateXEvent(&device_plane_builder, &op_line, "custom_call_with_model_flops",
                /*offset_ps=*/50,
                /*duration_ps=*/10,
@@ -816,14 +848,11 @@ TEST(ConvertXPlaneToOpStats,
                 {StatType::kUsesIci, int64_t{0}},
                 {StatType::kModelFlops, int64_t{5}}});
 
-  // Megacore event overlapping with on duty op -> should not double count
-  // (offset 15-25, overlaps with 10-20 and 20-30)
+  // Megacore event overlapping with ICI custom call (offset 15-25)
   CreateXEvent(&device_plane_builder, &op_line, "megacore_op",
                /*offset_ps=*/15,
                /*duration_ps=*/10, {{StatType::kHloCategory, "megacore"}});
 
-  // Non-custom call with uses_ici = 1 -> uses_ici shouldn't matter if it has
-  // flops (offset 60-70)
   CreateXEvent(&device_plane_builder, &op_line, "dot",
                /*offset_ps=*/60,
                /*duration_ps=*/10,
@@ -831,8 +860,6 @@ TEST(ConvertXPlaneToOpStats,
                 {StatType::kUsesIci, int64_t{1}},
                 {StatType::kFlops, int64_t{10}}});
 
-  // Non-custom call with uses_ici = 1, no flops -> it's active based on
-  // category unless IsOffDutyOp (offset 70-80)
   CreateXEvent(
       &device_plane_builder, &op_line, "add",
       /*offset_ps=*/70,
@@ -843,23 +870,72 @@ TEST(ConvertXPlaneToOpStats,
   xla_module_line.SetName(kXlaModuleLineName);
   CreateXEvent(&device_plane_builder, &xla_module_line, "module.1",
                /*offset_ps=*/5,
-               /*duration_ps=*/90);  // 5 to 95 (total length 90)
-
-  // Active times:
-  // 10-25 (custom call with ici from 10-20, extended to 25 by megacore_op)
-  // 30-40 (custom call with ici + flops)
-  // 50-60 (custom call with model flops)
-  // 60-70 (dot with flops)
-  // 70-80 (add)
-  // total active time = 15 + 10 + 10 + 10 + 10 = 55
-  // Module time = 90.
-  // Idle time = 90 - 55 = 35.
+               /*duration_ps=*/90);
 
   XPlaneVisitor visitor = tsl::profiler::CreateTfXPlaneVisitor(device_plane);
-  DutyCycleTracker tracker = ConstructDutyCycleTracker(visitor);
 
-  EXPECT_EQ(tracker.GetActiveTimePs(), 55);
-  EXPECT_EQ(tracker.GetIdleTimePs(), 35);
+  struct ModeCase {
+    CustomCallDutyCycleMode mode;
+    int64_t expected_active_ps;
+    int64_t expected_idle_ps;
+    const char* name;
+  };
+  // kLegacy: event-level hlo_category ignored -> all ops active: 10-80 = 70.
+  // kFlopsModel: ICI ignored; active = megacore(15-25)+flops(30-40)+
+  //   model_flops(50-60)+dot(60-70)+add(70-80) = 50.
+  // kIciAware: also custom_call_with_ici [10,20) merges with megacore to
+  //   [10,25) => active = 15+10+10+10+10 = 55 (historical f47b48c5 result).
+  const ModeCase kCases[] = {
+      {CustomCallDutyCycleMode::kLegacy, 70, 20, "legacy"},
+      {CustomCallDutyCycleMode::kFlopsModel, 50, 40, "flops_model"},
+      {CustomCallDutyCycleMode::kIciAware, 55, 35, "ici_aware"},
+  };
+  for (const auto& c : kCases) {
+    DutyCycleTracker tracker = ConstructDutyCycleTracker(visitor, c.mode);
+    EXPECT_EQ(tracker.GetActiveTimePs(), c.expected_active_ps) << c.name;
+    EXPECT_EQ(tracker.GetIdleTimePs(), c.expected_idle_ps) << c.name;
+  }
+}
+
+// Default ConstructDutyCycleTracker (no override) matches explicit kLegacy.
+TEST(ConvertXPlaneToOpStats, ConstructDutyCycleTrackerDefaultIsLegacy) {
+  // Ensure env default path is exercised (unset -> kLegacy).
+  unsetenv("XPROF_CUSTOM_CALL_DUTY_CYCLE_MODE");
+  XSpace space;
+  XPlane* device_plane = GetOrCreateTpuXPlane(
+      &space, /*device_ordinal=*/0, /*device_type=*/"TPU v4",
+      /*peak_tera_flops_per_second=*/0,
+      /*peak_hbm_bw_gigabytes_per_second=*/0);
+  XPlaneBuilder device_plane_builder(device_plane);
+  XLineBuilder op_line = device_plane_builder.GetOrCreateLine(0);
+  op_line.SetName(kXlaOpLineName);
+  // Metadata-level infeed (classic off-duty) + event-level custom-call with
+  // flops=0. Legacy must treat infeed as idle and custom-call as active.
+  CreateXEventMetadata(&device_plane_builder, "infeed_op",
+                       {{StatType::kHloCategory, tsl::profiler::kHloInfeed}});
+  CreateXEvent(&device_plane_builder, &op_line, "infeed_op", /*offset_ps=*/10,
+               /*duration_ps=*/10);
+  CreateXEvent(&device_plane_builder, &op_line, "custom_call_0_flops",
+               /*offset_ps=*/20,
+               /*duration_ps=*/10,
+               {{StatType::kHloCategory,
+                 xla::HloOpcodeString(xla::HloOpcode::kCustomCall)},
+                {StatType::kFlops, int64_t{0}}});
+  XLineBuilder xla_module_line = device_plane_builder.GetOrCreateLine(1);
+  xla_module_line.SetName(kXlaModuleLineName);
+  CreateXEvent(&device_plane_builder, &xla_module_line, "module.1",
+               /*offset_ps=*/5, /*duration_ps=*/50);
+
+  XPlaneVisitor visitor = tsl::profiler::CreateTfXPlaneVisitor(device_plane);
+  DutyCycleTracker default_tracker = ConstructDutyCycleTracker(visitor);
+  DutyCycleTracker legacy_tracker =
+      ConstructDutyCycleTracker(visitor, CustomCallDutyCycleMode::kLegacy);
+  EXPECT_EQ(default_tracker.GetActiveTimePs(),
+            legacy_tracker.GetActiveTimePs());
+  EXPECT_EQ(default_tracker.GetIdleTimePs(), legacy_tracker.GetIdleTimePs());
+  // Only custom-call is active under legacy (infeed off-duty): active=10.
+  EXPECT_EQ(default_tracker.GetActiveTimePs(), 10);
+  EXPECT_EQ(default_tracker.GetIdleTimePs(), 40);
 }
 
 TEST(ConvertXPlaneToOpStats, MultiCoreChipBusyAndIdleTimeTest) {


### PR DESCRIPTION
## Summary
Flag-gates historical CustomCall duty-cycle logic behind an opt-in env var. **Default behavior is unchanged** (post-#2942 / after the #2942-era revert): only `IsOffDutyOp` HLO categories are off-duty; CustomCall is not special-cased.

### Modes (`XPROF_CUSTOM_CALL_DUTY_CYCLE_MODE`)
| Value | Behavior |
|-------|----------|
| `legacy` (default / unset / unknown) | Metadata `hlo_category` + `IsOffDutyOp` only |
| `flops_model` | CustomCall off-duty iff `flops==0 && model_flops==0` (commit `48cc8012`) |
| `ici_aware` | `flops_model` + force on-duty when `uses_ici != 0` (commit `f47b48c5`) |

### Implementation
- `CustomCallDutyCycleMode` enum + `ParseCustomCallDutyCycleMode` / `GetCustomCallDutyCycleModeFromEnv`
- `IsCustomCallOffDuty(...)` used only when mode != `kLegacy`
- `ConstructDutyCycleTracker(visitor, mode_override=nullopt)` — override for tests; production uses env
- Legacy path intentionally keeps Metadata-only `hlo_category` lookup (bit-identical default)

### Docs
- Short semantics note under TPU Duty Cycle in `docs/overview_page.md`

## Test plan
- [x] Table-driven gunit tests for mode parsing and CustomCall flops / ICI fixtures under all three modes
- [x] Default (env unset) matches explicit `kLegacy`
- [ ] CI: `//xprof/convert:xplane_to_op_stats_test`
- Local bazel blocked on this host (CommandLineTools only; apple crosstool requests macosx10.11 SDK)

## Product constraint
DEFAULT must remain identical to current post-#2942 code — never change defaults silently.