### PR TITLE
test(trace_viewer_v2): shared overlap fixtures for packer and self-time

### DIFF
--- a/frontend/app/components/trace_viewer_v2/timeline/BUILD
+++ b/frontend/app/components/trace_viewer_v2/timeline/BUILD
@@ -132,6 +132,7 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@imgui",
         "@org_xprof//frontend/app/components/trace_viewer_v2/color:colors",
+        "@org_xprof//frontend/app/components/trace_viewer_v2/trace_helper:overlap_interval_test_fixtures",
         "@org_xprof//frontend/app/components/trace_viewer_v2/trace_helper:trace_event",
         "@tsl//tsl/profiler/lib:context_types_hdrs",
     ],

--- a/frontend/app/components/trace_viewer_v2/timeline/data_provider_test.cc
+++ b/frontend/app/components/trace_viewer_v2/timeline/data_provider_test.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
@@ -16,6 +17,7 @@
 #include "frontend/app/components/trace_viewer_v2/color/colors.h"
 #include "frontend/app/components/trace_viewer_v2/timeline/time_range.h"
 #include "frontend/app/components/trace_viewer_v2/timeline/timeline.h"
+#include "frontend/app/components/trace_viewer_v2/trace_helper/overlap_interval_test_fixtures.h"
 #include "frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h"
 
 namespace traceviewer {
@@ -23,9 +25,20 @@ namespace traceviewer {
 namespace {
 
 using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
+
+using test_fixtures::ExclusiveEndpointScenario;
+using test_fixtures::ExpectedLevels;
+using test_fixtures::ExpectedNames;
+using test_fixtures::ExpectedSelfTimes;
+using test_fixtures::MakeDataProviderEvents;
+using test_fixtures::NestedOverlapScenario;
+using test_fixtures::OverlapRowReuseScenario;
+using test_fixtures::OverlapScenarioEvent;
+using test_fixtures::PartialOverlapScenario;
 
 TraceEvent CreateMetadataEvent(std::string event_name, ProcessId pid,
                                ThreadId tid,
@@ -336,6 +349,60 @@ TEST_F(DataProviderTest, ProcessOverlappingNonNestedEvents) {
   EXPECT_THAT(data.entry_total_times, ElementsAre(50.0, 50.0));
   EXPECT_THAT(data.entry_self_times, ElementsAre(50.0, 50.0));
   EXPECT_THAT(data.entry_levels, ElementsAre(0, 1));
+}
+
+// Joint packing × self-time invariants for a shared overlap scenario.
+// Asserts: no events dropped, packer levels match fixture, self-times match
+// BuildTree expectations. Mirrors TraceEventPackerTest.SharedFixture* cases.
+void ExpectDataProviderMatchesScenario(
+    DataProvider& data_provider, Timeline& timeline,
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  const std::vector<TraceEvent> events = MakeDataProviderEvents(scenario);
+  data_provider.ProcessTraceEvents({events, {}}, timeline);
+
+  const FlameChartTimelineData& data = timeline.timeline_data();
+
+  // Packer must not drop or merge events.
+  ASSERT_THAT(data.entry_names, SizeIs(scenario.size()));
+  EXPECT_THAT(data.entry_names, ElementsAreArray(ExpectedNames(scenario)));
+  EXPECT_THAT(data.entry_levels, ElementsAreArray(ExpectedLevels(scenario)));
+  EXPECT_THAT(data.entry_self_times,
+              ElementsAreArray(ExpectedSelfTimes(scenario)));
+
+  // Self-time is never negative and never exceeds wall (total) time.
+  for (size_t i = 0; i < data.entry_self_times.size(); ++i) {
+    EXPECT_GE(data.entry_self_times[i], 0.0) << "index " << i;
+    EXPECT_LE(data.entry_self_times[i], data.entry_total_times[i])
+        << "index " << i;
+  }
+}
+
+TEST_F(DataProviderTest, SharedFixtureNestedOverlapPackingAndSelfTime) {
+  const auto scenario = NestedOverlapScenario();
+  ExpectDataProviderMatchesScenario(data_provider_, timeline_, scenario);
+
+  // Pure nesting: sum of self-times equals the root wall time.
+  const auto self_times = ExpectedSelfTimes(scenario);
+  const double self_sum =
+      std::accumulate(self_times.begin(), self_times.end(), 0.0);
+  EXPECT_DOUBLE_EQ(self_sum, scenario.front().dur);
+}
+
+TEST_F(DataProviderTest, SharedFixturePartialOverlapPackingAndSelfTime) {
+  ExpectDataProviderMatchesScenario(data_provider_, timeline_,
+                                    PartialOverlapScenario());
+}
+
+TEST_F(DataProviderTest, SharedFixtureExclusiveEndpointPackingAndSelfTime) {
+  // Exclusive-end policy: adjacent events share level 0 and keep full
+  // self-time (same fixture as TraceEventPackerTest.SharedFixtureExclusiveEndpoint).
+  ExpectDataProviderMatchesScenario(data_provider_, timeline_,
+                                    ExclusiveEndpointScenario());
+}
+
+TEST_F(DataProviderTest, SharedFixtureOverlapRowReusePackingAndSelfTime) {
+  ExpectDataProviderMatchesScenario(data_provider_, timeline_,
+                                    OverlapRowReuseScenario());
 }
 
 TEST_F(DataProviderTest, ProcessNonOverlappingCompleteEventsSameThread) {

--- a/frontend/app/components/trace_viewer_v2/trace_helper/BUILD
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/BUILD
@@ -181,10 +181,22 @@ wasm_cc_library(
     ],
 )
 
+# Header-only shared fixtures connecting packer row assignment and self-time
+# invariants (used by packer_test and timeline/data_provider_test).
+cc_library(
+    name = "overlap_interval_test_fixtures",
+    testonly = True,
+    hdrs = ["overlap_interval_test_fixtures.h"],
+    deps = [
+        ":trace_event",
+    ],
+)
+
 cc_test(
     name = "trace_event_packer_test",
     srcs = ["trace_event_packer_test.cc"],
     deps = [
+        ":overlap_interval_test_fixtures",
         ":trace_event",
         ":trace_event_packer",
         "@com_google_absl//absl/types:span",

--- a/frontend/app/components/trace_viewer_v2/trace_helper/overlap_interval_test_fixtures.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/overlap_interval_test_fixtures.h
@@ -1,0 +1,161 @@
+#ifndef THIRD_PARTY_XPROF_FRONTEND_APP_COMPONENTS_TRACE_VIEWER_V2_TRACE_HELPER_OVERLAP_INTERVAL_TEST_FIXTURES_H_
+#define THIRD_PARTY_XPROF_FRONTEND_APP_COMPONENTS_TRACE_VIEWER_V2_TRACE_HELPER_OVERLAP_INTERVAL_TEST_FIXTURES_H_
+
+#include <string>
+#include <vector>
+
+#include "frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h"
+
+namespace traceviewer {
+namespace test_fixtures {
+
+// Shared overlapping-interval scenarios used by both the packer
+// (trace_event_packer_test) and self-time / data-provider paths
+// (data_provider_test). Keeping one fixture source prevents packing row
+// assignment and hierarchy-aware self-time from silently diverging
+// (see openxla/xprof#2939, #2919).
+//
+// Interval model matches PackTraceEvents:
+//   Events occupy half-open ranges [ts, ts+dur). An event that starts at
+//   exactly another event's end time does not overlap it (exclusive end).
+
+// One event in a shared scenario plus the expected packer level and
+// hierarchy-aware self-time after packing + tree construction.
+struct OverlapScenarioEvent {
+  const char* name;
+  Microseconds ts;
+  Microseconds dur;
+  // 0-based visual level assigned by PackTraceEvents within the track.
+  int expected_level;
+  // Self-time after BuildTree subtraction of fully-contained children.
+  Microseconds expected_self_time;
+};
+
+// Nested parent/child chain:
+//
+//   |---------- Parent [100,200) ----------|
+//      |---- Child [110,160) ----|
+//         | Grand [120,140) |
+//
+// Pack levels: Parent=0, Child=1, Grand=2
+// Self times:  Parent=50 (100-50), Child=30 (50-20), Grand=20
+// Invariant: sum(self_times) == root wall time for pure nesting.
+inline std::vector<OverlapScenarioEvent> NestedOverlapScenario() {
+  return {
+      {"Parent", 100.0, 100.0, /*expected_level=*/0, /*expected_self_time=*/50.0},
+      {"Child", 110.0, 50.0, /*expected_level=*/1, /*expected_self_time=*/30.0},
+      {"Grand", 120.0, 20.0, /*expected_level=*/2, /*expected_self_time=*/20.0},
+  };
+}
+
+// Non-nested partial overlap: B starts inside A but ends after A.
+// The tree does not treat B as a child of A; both keep full duration as
+// self-time. The packer still stacks them on different rows.
+//
+//   |----- A [100,150) -----|
+//          |----- B [120,170) -----|
+//
+// Pack levels: A=0, B=1
+// Self times:  A=50, B=50
+inline std::vector<OverlapScenarioEvent> PartialOverlapScenario() {
+  return {
+      {"A", 100.0, 50.0, /*expected_level=*/0, /*expected_self_time=*/50.0},
+      {"B", 120.0, 50.0, /*expected_level=*/1, /*expected_self_time=*/50.0},
+  };
+}
+
+// Endpoint adjacency under the exclusive-end policy: B starts exactly when
+// A ends, so they must share a packer row and keep independent self-times.
+//
+//   |-- A [10,30) --||-- B [30,50) --|
+//
+// Pack levels: A=0, B=0
+// Self times:  A=20, B=20
+inline std::vector<OverlapScenarioEvent> ExclusiveEndpointScenario() {
+  return {
+      {"A", 10.0, 20.0, /*expected_level=*/0, /*expected_self_time=*/20.0},
+      {"B", 30.0, 20.0, /*expected_level=*/0, /*expected_self_time=*/20.0},
+  };
+}
+
+// Overlap with later row reuse (classic packer case):
+//
+//   |-- A [10,30) --|
+//          |-- B [20,40) --|
+//                     |-- C [35,50) --|  reuses level 0 after A ends
+//
+// Pack levels: A=0, B=1, C=0
+// Self times:  A=20, B=20, C=15 (none nested)
+inline std::vector<OverlapScenarioEvent> OverlapRowReuseScenario() {
+  return {
+      {"A", 10.0, 20.0, /*expected_level=*/0, /*expected_self_time=*/20.0},
+      {"B", 20.0, 20.0, /*expected_level=*/1, /*expected_self_time=*/20.0},
+      {"C", 35.0, 15.0, /*expected_level=*/0, /*expected_self_time=*/15.0},
+  };
+}
+
+// Minimal TraceEvent list for packer unit tests (name/ts/dur only).
+inline std::vector<TraceEvent> MakePackerEvents(
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  std::vector<TraceEvent> events;
+  events.reserve(scenario.size());
+  for (const auto& e : scenario) {
+    events.push_back(TraceEvent{.name = e.name, .ts = e.ts, .dur = e.dur});
+  }
+  return events;
+}
+
+// Complete-phase TraceEvent list for DataProvider / self-time integration.
+inline std::vector<TraceEvent> MakeDataProviderEvents(
+    const std::vector<OverlapScenarioEvent>& scenario, ProcessId pid = 1,
+    ThreadId tid = 101) {
+  std::vector<TraceEvent> events;
+  events.reserve(scenario.size());
+  for (const auto& e : scenario) {
+    events.push_back(TraceEvent{.ph = Phase::kComplete,
+                                .pid = pid,
+                                .tid = tid,
+                                .name = e.name,
+                                .ts = e.ts,
+                                .dur = e.dur});
+  }
+  return events;
+}
+
+// Expected packer levels in chronological (packer output) order.
+inline std::vector<int> ExpectedLevels(
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  std::vector<int> levels;
+  levels.reserve(scenario.size());
+  for (const auto& e : scenario) {
+    levels.push_back(e.expected_level);
+  }
+  return levels;
+}
+
+// Expected self-times in chronological (packer output) order.
+inline std::vector<Microseconds> ExpectedSelfTimes(
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  std::vector<Microseconds> self_times;
+  self_times.reserve(scenario.size());
+  for (const auto& e : scenario) {
+    self_times.push_back(e.expected_self_time);
+  }
+  return self_times;
+}
+
+// Expected names in chronological (packer output) order.
+inline std::vector<std::string> ExpectedNames(
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  std::vector<std::string> names;
+  names.reserve(scenario.size());
+  for (const auto& e : scenario) {
+    names.push_back(e.name);
+  }
+  return names;
+}
+
+}  // namespace test_fixtures
+}  // namespace traceviewer
+
+#endif  // THIRD_PARTY_XPROF_FRONTEND_APP_COMPONENTS_TRACE_VIEWER_V2_TRACE_HELPER_OVERLAP_INTERVAL_TEST_FIXTURES_H_

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_packer.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_packer.h
@@ -21,9 +21,26 @@ struct PackedEvent {
 // assigned to different levels, while nested events are assigned to consecutive
 // levels to represent parent-child relationships visually.
 //
-// events is a span of pointers to trace events.Returns a vector of
-// `PackedEvent` entries ordered chronologically by event start time
-// (ascending), with tie-breaking by duration (descending).
+// Endpoint / overlap policy (half-open intervals):
+//   Each event occupies the half-open range [ts, ts + dur). Two events
+//   overlap (and therefore cannot share a visual level) iff their ranges
+//   intersect. In particular:
+//     - An event that ends at time T and another that starts at time T do
+//       NOT overlap: the first event's end is exclusive, so the second may
+//       reuse the same level (row). Implementation: a row is free when
+//       row_end_time <= candidate_start.
+//     - Zero-duration events occupy an empty range [ts, ts) and never block
+//       later events that start at ts.
+//   Nested containment uses the same half-open model: event B is nested
+//   under A when A.ts <= B.ts and B.ts + B.dur <= A.ts + A.dur. Partial
+//   (non-nested) overlaps are stacked on different levels rather than merged
+//   or dropped — every input event appears exactly once in the output.
+//
+// events is a span of pointers to trace events. Null pointers are ignored.
+// Returns a vector of `PackedEvent` entries ordered chronologically by event
+// start time (ascending), with tie-breaking by duration (descending) so that
+// longer parent events are packed before shorter children that start at the
+// same timestamp.
 std::vector<PackedEvent> PackTraceEvents(
     absl::Span<const TraceEvent* const> events);
 

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_packer_test.cc
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_packer_test.cc
@@ -1,13 +1,24 @@
 #include "frontend/app/components/trace_viewer_v2/trace_helper/trace_event_packer.h"
 
+#include <string>
 #include <vector>
 
 #include "<gtest/gtest.h>"
 #include "absl/types/span.h"
+#include "frontend/app/components/trace_viewer_v2/trace_helper/overlap_interval_test_fixtures.h"
 #include "frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h"
 
 namespace traceviewer {
 namespace {
+
+using test_fixtures::ExclusiveEndpointScenario;
+using test_fixtures::ExpectedLevels;
+using test_fixtures::ExpectedNames;
+using test_fixtures::MakePackerEvents;
+using test_fixtures::NestedOverlapScenario;
+using test_fixtures::OverlapRowReuseScenario;
+using test_fixtures::OverlapScenarioEvent;
+using test_fixtures::PartialOverlapScenario;
 
 std::vector<const TraceEvent*> GetEventPointers(
     absl::Span<const TraceEvent> events) {
@@ -17,6 +28,26 @@ std::vector<const TraceEvent*> GetEventPointers(
     events_ptr.push_back(&event);
   }
   return events_ptr;
+}
+
+// Asserts packer preserves every input event and assigns the fixture's
+// expected visual levels. Shared with data_provider self-time tests via
+// overlap_interval_test_fixtures.h.
+void ExpectPackedMatchesScenario(
+    const std::vector<OverlapScenarioEvent>& scenario) {
+  const std::vector<TraceEvent> events = MakePackerEvents(scenario);
+  auto events_ptr = GetEventPointers(events);
+  const auto packed = PackTraceEvents(events_ptr);
+
+  // No events may be dropped or merged by packing.
+  ASSERT_EQ(packed.size(), scenario.size());
+
+  const std::vector<std::string> expected_names = ExpectedNames(scenario);
+  const std::vector<int> expected_levels = ExpectedLevels(scenario);
+  for (size_t i = 0; i < packed.size(); ++i) {
+    EXPECT_EQ(packed[i].event->name, expected_names[i]) << "index " << i;
+    EXPECT_EQ(packed[i].level, expected_levels[i]) << "index " << i;
+  }
 }
 
 TEST(TraceEventPackerTest, EmptyEvents) {
@@ -129,6 +160,25 @@ TEST(TraceEventPackerTest, IgnoresNullPointers) {
   EXPECT_EQ(packed[0].level, 0);
   EXPECT_EQ(packed[1].event->name, "B");
   EXPECT_EQ(packed[1].level, 1);
+}
+
+// --- Shared overlap fixtures (joint with data_provider self-time tests) ---
+
+TEST(TraceEventPackerTest, SharedFixtureNestedOverlap) {
+  ExpectPackedMatchesScenario(NestedOverlapScenario());
+}
+
+TEST(TraceEventPackerTest, SharedFixturePartialOverlap) {
+  ExpectPackedMatchesScenario(PartialOverlapScenario());
+}
+
+TEST(TraceEventPackerTest, SharedFixtureExclusiveEndpoint) {
+  // Exclusive end: B starts at A's end and must reuse level 0.
+  ExpectPackedMatchesScenario(ExclusiveEndpointScenario());
+}
+
+TEST(TraceEventPackerTest, SharedFixtureOverlapRowReuse) {
+  ExpectPackedMatchesScenario(OverlapRowReuseScenario());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Connects TV2 event packing and hierarchy-aware self-time with **shared overlapping-interval fixtures**, so row assignment and self-time cannot silently disagree (critique of #2939 / #2919).

Also documents the packer's **half-open** `[ts, ts+dur)` endpoint / overlap policy on `PackTraceEvents`.

### Changes
- New `overlap_interval_test_fixtures.h` (testonly) with four scenarios:
  - nested parent/child/grandchild
  - non-nested partial overlap
  - exclusive-end adjacency (row reuse)
  - overlap + later row reuse
- `trace_event_packer_test` and `data_provider_test` both assert levels / counts / self-times from those fixtures
- Joint invariants: no events dropped; self-time ∈ [0, wall]; pure nesting sum(self) == root wall time
- Packer header documents inclusive-start / exclusive-end overlap rules

### Out of scope (optional FIX-029/038/043)
Golden selection-bounds expansion and instant hit-target / zero-height styling left for follow-up if needed; selection math already has coverage in `timeline_test`.

## Test plan
- [x] `//frontend/app/components/trace_viewer_v2/trace_helper:trace_event_packer_test` — 12/12 PASSED (incl. 4 SharedFixture*)
- [x] `//frontend/app/components/trace_viewer_v2/timeline:data_provider_test` — 90/90 PASSED (incl. 4 SharedFixture*)