### PR TITLE
docs: critique-followup docs cluster (profiling, lint, memory leaks)

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,32 @@
+# Markdownlint configuration for XProf documentation under docs/.
+#
+# Install (optional, one-shot via npx — no repo dependency required):
+#   npx markdownlint-cli2 "docs/**/*.md"
+#
+# Or with a local install:
+#   npm install -g markdownlint-cli2
+#   markdownlint-cli2 "docs/**/*.md"
+#
+# Primary goal: catch recurring emphasis/bolding defects (e.g. spaces inside
+# **bold** markers) without failing the whole tree on historical style choices
+# such as long lines, inline HTML, or non-H1 first lines.
+
+default: true
+
+# Line length — many existing docs use long prose lines and tables.
+MD013: false
+
+# Duplicate headings are common across independent sections/pages.
+MD024: false
+
+# Ordered list style varies (all-1s vs incrementing) in historical docs.
+MD029: false
+
+# Allow inline HTML used for notes, images, and layout in docs/.
+MD033: false
+
+# Files may start with blockquotes / front matter-like notes before H1.
+MD041: false
+
+# Keep emphasis rules that catch broken **bold** / _italic_ (MD037 et al.).
+# MD037: spaces inside emphasis markers — enabled via default: true

--- a/README.md
+++ b/README.md
@@ -358,6 +358,16 @@ workers for processing.
 For deploying a distributed XProf setup in a Kubernetes environment, see
 [Kubernetes Deployment Guide](docs/kubernetes_deployment.md).
 
+## Documentation
+
+User-facing guides live under [`docs/`](docs/). Markdown lint rules for those
+pages are defined in [`.markdownlint.yaml`](.markdownlint.yaml). To check docs
+locally (no repo npm dependency required):
+
+```
+$ npx markdownlint-cli2 "docs/**/*.md"
+```
+
 ## Resources
 
   * [JAX Profiling

--- a/docs/advanced_profiler_options.md
+++ b/docs/advanced_profiler_options.md
@@ -77,8 +77,33 @@ TPU.
 *   **`max_trace_buffers`** (Integer): Controls the maximum size of trace
     buffers.
 *   **`tpu_circular_buffer_tracing`** (Boolean): Enables circular buffer
-    tracing.
+    tracing. When enabled, trace events are written into fixed-size circular
+    buffers so recent history is retained without unbounded growth. Often used
+    together with continuous profiling (see below).
 *   **`enable_continuous_profiling`** (Boolean): Enables continuous profiling.
+    **Default:** `false` (disabled). When `true`, the profiler keeps collecting
+    events for the lifetime of the profiling session so you can take a
+    [snapshot at an arbitrary instant](capturing_profiles.md#continuous-profiling-snapshots)
+    rather than only for a pre-scheduled window.
+
+    **Overhead / resource impact:** Continuous profiling keeps device (and
+    optionally host) tracers active and typically relies on circular trace
+    buffers. Expect:
+
+    *   Ongoing CPU cost to record events while the workload runs;
+    *   Resident memory for circular / max trace buffers (see also
+        `max_trace_buffers` and `tpu_circular_buffer_tracing`);
+    *   Larger or more frequent on-disk profile dumps when snapshots are
+        taken;
+    *   Possible perturbation of step-time measurements compared with short,
+        targeted captures.
+
+    Prefer short diagnostic windows (enable → reproduce issue →
+    `get_snapshot` / stop) over leaving continuous profiling enabled for an
+    entire multi-hour training or inference job. For API-based continuous
+    snapshot capture, see
+    [Capture continuous profiling snapshots](jax_profiling.md#capture-continuous-profiling-snapshots)
+    and [Capturing profiles](capturing_profiles.md#continuous-profiling-snapshots).
 *   **`tpu_watched_sync_flag_number`** (Integer): Watched sync flag number.
 *   **`tpu_watched_sync_flag_mask`** (Integer): Watched sync flag mask.
 *   **`tpu_sc_dma`** (Boolean): Controls TPU SC DMA tracing.

--- a/docs/capturing_profiles.md
+++ b/docs/capturing_profiles.md
@@ -49,6 +49,30 @@ within your code. In JAX, for example, enabling
 will start an `xprof` server on your ML workload which is listening for the
 snapshot profiling trigger to start capturing profiles.
 
+You can also pass `enable_continuous_profiling: true` (and optionally
+`tpu_circular_buffer_tracing: true`) via
+[`profiler_options` / advanced configuration](advanced_profiler_options.md)
+when starting a trace. Continuous profiling is **off by default**.
+
+### Overhead
+
+While continuous profiling is active, tracers keep recording into circular
+buffers so a recent window of events is always available for `get_snapshot`.
+That ongoing collection has a non-trivial cost:
+
+- **CPU:** event recording runs alongside your training/inference step;
+- **Memory:** circular / max trace buffers stay resident for the session;
+- **I/O:** writing snapshots can produce large profile directories;
+- **Measurement noise:** long-running continuous collection can slightly
+  perturb step times relative to short programmatic or on-demand captures.
+
+Use continuous profiling when you need to freeze a timeline at the moment a
+problem appears (stragglers, rare stalls, production incidents). For routine
+tuning, prefer short programmatic or on-demand captures. Stop continuous
+profiling when you are done so the workload is no longer paying that overhead.
+Framework-specific start/stop/snapshot steps for JAX are in
+[Capture continuous profiling snapshots](jax_profiling.md#capture-continuous-profiling-snapshots).
+
 ## XProf and Tensorboard on Google Cloud
 
 On Google Cloud, we recommend using

--- a/docs/jax_profiling.md
+++ b/docs/jax_profiling.md
@@ -135,7 +135,12 @@ for more details on using the trace viewer.
 ## Capture continuous profiling snapshots
 
 The following are the instructions to capture a continuous profiling snapshot at
-any time instant.
+any time instant. Continuous profiling keeps tracers active so a recent window
+of events can be snapshotted on demand; it is **off by default** and has ongoing
+CPU/memory overhead. Prefer short enable → snapshot → stop windows. See
+[Advanced Profiler Options](advanced_profiler_options.md) and
+[Capturing profiles](capturing_profiles.md#continuous-profiling-snapshots) for
+defaults and resource impact.
 
 1. In the Python program or process you'd like to profile, add the following
 somewhere near the beginning:

--- a/docs/memory_leaks.md
+++ b/docs/memory_leaks.md
@@ -77,3 +77,21 @@ Use Memory Viewer for a detailed static analysis of buffer lifetimes.
     deallocate will have bars extending to the end.
 
     ![Memory Viewer tool showing buffer charts with long-lived allocations](./images/buffer_charts_memory_leaks.png)
+
+## Related: Trace Viewer WASM heap ownership (frontend)
+
+This guide focuses on **model** tensor and buffer lifetimes in captured
+profiles. Separately, Trace Viewer v2 allocates temporary buffers on the
+WebAssembly heap when transferring compressed or binary trace payloads from
+JavaScript into native code. Those allocations must be paired with `_free`
+(or an always-free helper) so the browser tab does not grow without bound
+during large trace loads or search.
+
+Verified free conventions and helpers live at:
+
+- [`frontend/app/components/trace_viewer_v2/wasm_string_utils.ts`](../frontend/app/components/trace_viewer_v2/wasm_string_utils.ts)
+  (lands with the WASM string free conventions change; path relative to the
+  repository root)
+
+Prefer `withWasmHeapBuffer` / `withWasmCString` / `freeWasmPtr` from that
+module at new call sites rather than raw `_malloc` / `_free` pairs.


### PR DESCRIPTION
## Summary

Docs-only follow-up cluster for critique fixes **FIX-020**, **FIX-022**, **FIX-034**, **FIX-042** (FIX-028 Orbax skipped — no in-tree Orbax paths/fixtures to document cleanly).

- **Continuous profiling overhead (FIX-020 / #2782):** Expand `enable_continuous_profiling` beyond a one-line flag. Document default (`false`), resource impact (CPU, circular/max buffers, I/O, measurement noise), and when to enable. Covered in `docs/advanced_profiler_options.md`, `docs/capturing_profiles.md`, and a short pointer in `docs/jax_profiling.md`.
- **SparseCoreOffloadRule docs sync (FIX-022 / #2910):** Grep of `docs/`, CLI help, and README found **no** user-facing references to the unregistered `SparseCoreOffloadRule`. No doc deletions required; rule remains unregistered in `all_rules.h` (header/tests still present in code).
- **Markdownlint for docs (FIX-034 / #2709/#2819):** Add root `.markdownlint.yaml` tuned for `docs/` (keep emphasis/bolding rules; relax line length, HTML, first-line H1, etc.). Document `npx markdownlint-cli2 "docs/**/*.md"` in README.
- **memory_leaks.md ↔ WASM free helpers (FIX-042):** Link model-tensor leak guide to Trace Viewer v2 WASM heap helpers at `frontend/app/components/trace_viewer_v2/wasm_string_utils.ts` (path from PR-B / FIX-002; file lands with that change).

## Test plan

- [x] Grep `SparseCoreOffload` under `docs/`, CLI, README — no stale hits
- [x] Manual review of continuous-profiling overhead wording vs `StartContinuousProfiling` (circular buffer + long-lived tracers)
- [ ] Optional: `npx markdownlint-cli2 "docs/**/*.md"` (config added; full tree may still report pre-existing style issues outside the enabled emphasis rules)
- [ ] Docs-only PR — no code/build required