### PR TITLE
fix(plugin): bound decompressed protobuf trace size

### DIFF
--- a/plugin/xprof/convert/raw_to_tool_data.py
+++ b/plugin/xprof/convert/raw_to_tool_data.py
@@ -24,7 +24,10 @@ from __future__ import division
 from __future__ import print_function
 
 from collections.abc import Callable, Mapping, Sequence
+import gzip
+import io
 import logging
+import struct
 from typing import Any
 
 from xprof.convert import csv_writer
@@ -36,6 +39,196 @@ from xprof.convert import _pywrap_profiler_plugin
 
 
 logger = logging.getLogger('tensorboard')
+
+# Hard cap on decompressed protobuf/gzip trace payloads. Guards against
+# decompression bombs when serving format=pb compressed traces. Override in
+# tests via the max_decompressed_bytes parameter on the helpers below.
+MAX_DECOMPRESSED_TRACE_BYTES = 512 * 1024 * 1024  # 512 MiB
+
+_GZIP_MAGIC = b'\x1f\x8b'
+_ZSTD_MAGIC = b'\x28\xb5\x2f\xfd'
+_GZIP_READ_CHUNK = 1024 * 1024  # 1 MiB
+
+
+class CompressedTraceError(ValueError):
+  """Raised when a compressed trace is corrupt or exceeds size limits."""
+
+
+def _gzip_decompress_bounded(
+    data: bytes, max_decompressed_bytes: int
+) -> bytes:
+  """Decompress gzip data, rejecting corrupt streams and oversize output."""
+  try:
+    decoder = gzip.GzipFile(fileobj=io.BytesIO(data), mode='rb')
+  except Exception as exc:  # pylint: disable=broad-except
+    raise CompressedTraceError(
+        f'corrupt gzip compressed trace: {exc}'
+    ) from exc
+
+  out = io.BytesIO()
+  total = 0
+  try:
+    while True:
+      chunk = decoder.read(_GZIP_READ_CHUNK)
+      if not chunk:
+        break
+      total += len(chunk)
+      if total > max_decompressed_bytes:
+        raise CompressedTraceError(
+            'decompressed gzip trace exceeds limit of'
+            f' {max_decompressed_bytes} bytes'
+        )
+      out.write(chunk)
+  except CompressedTraceError:
+    raise
+  except EOFError as exc:
+    raise CompressedTraceError(
+        f'corrupt gzip compressed trace: truncated stream: {exc}'
+    ) from exc
+  except OSError as exc:
+    raise CompressedTraceError(
+        f'corrupt gzip compressed trace: {exc}'
+    ) from exc
+  return out.getvalue()
+
+
+def _zstd_declared_content_size(data: bytes) -> int:
+  """Return Frame_Content_Size from a zstd frame header.
+
+  Raises:
+    CompressedTraceError: If the frame is truncated, reserved bits are set,
+      or content size is not declared in the header.
+  """
+  if len(data) < 5:
+    raise CompressedTraceError('corrupt zstd compressed trace: truncated header')
+  if not data.startswith(_ZSTD_MAGIC):
+    raise CompressedTraceError('corrupt zstd compressed trace: bad magic')
+
+  descriptor = data[4]
+  # Bit 4 is unused (must be 0); bit 3 is reserved (must be 0).
+  if descriptor & 0x18:
+    raise CompressedTraceError(
+        'corrupt zstd compressed trace: reserved/unused header bits set'
+    )
+
+  fcs_flag = (descriptor >> 6) & 0x3
+  single_segment = bool(descriptor & 0x20)
+  dict_id_flag = descriptor & 0x3
+
+  offset = 5  # past magic + descriptor
+  if not single_segment:
+    # Window_Descriptor is present when Single_Segment is clear.
+    if len(data) < offset + 1:
+      raise CompressedTraceError(
+          'corrupt zstd compressed trace: truncated window descriptor'
+      )
+    offset += 1
+
+  dict_id_sizes = (0, 1, 2, 4)
+  dict_id_size = dict_id_sizes[dict_id_flag]
+  if len(data) < offset + dict_id_size:
+    raise CompressedTraceError(
+        'corrupt zstd compressed trace: truncated dictionary id'
+    )
+  offset += dict_id_size
+
+  if fcs_flag == 0:
+    fcs_size = 1 if single_segment else 0
+  elif fcs_flag == 1:
+    fcs_size = 2
+  elif fcs_flag == 2:
+    fcs_size = 4
+  else:
+    fcs_size = 8
+
+  if fcs_size == 0:
+    raise CompressedTraceError(
+        'corrupt zstd compressed trace: missing frame content size'
+        ' (decompressed size unknown; refusing to process)'
+    )
+  if len(data) < offset + fcs_size:
+    raise CompressedTraceError(
+        'corrupt zstd compressed trace: truncated frame content size'
+    )
+
+  fcs_bytes = data[offset : offset + fcs_size]
+  if fcs_size == 1:
+    content_size = fcs_bytes[0]
+  elif fcs_size == 2:
+    # 2-byte FCS stores (size - 256).
+    content_size = struct.unpack('<H', fcs_bytes)[0] + 256
+  elif fcs_size == 4:
+    content_size = struct.unpack('<I', fcs_bytes)[0]
+  else:
+    content_size = struct.unpack('<Q', fcs_bytes)[0]
+  return content_size
+
+
+def ensure_compressed_trace_within_bounds(
+    data: bytes,
+    max_decompressed_bytes: int = MAX_DECOMPRESSED_TRACE_BYTES,
+) -> None:
+  """Validate compressed protobuf/gzip trace payloads against size limits.
+
+  Uncompressed (non-gzip, non-zstd) bytes are left unchecked so legacy and
+  mock payloads keep working. Gzip streams are fully decompressed under a
+  hard size cap. Zstd frames are checked via the declared Frame_Content_Size
+  in the frame header (what the C++ producer writes) without requiring a
+  zstd Python dependency.
+
+  Args:
+    data: Raw tool payload bytes (possibly gzip or zstd compressed).
+    max_decompressed_bytes: Maximum allowed decompressed size.
+
+  Raises:
+    CompressedTraceError: If the payload is a corrupt compressed stream or
+      its decompressed size would exceed ``max_decompressed_bytes``.
+  """
+  if not data:
+    return
+  if data.startswith(_GZIP_MAGIC):
+    _gzip_decompress_bounded(data, max_decompressed_bytes)
+    return
+  if data.startswith(_ZSTD_MAGIC):
+    content_size = _zstd_declared_content_size(data)
+    if content_size > max_decompressed_bytes:
+      raise CompressedTraceError(
+          'decompressed zstd trace exceeds limit of'
+          f' {max_decompressed_bytes} bytes (declared {content_size} bytes)'
+      )
+    return
+
+
+def decompress_trace_data(
+    data: bytes,
+    max_decompressed_bytes: int = MAX_DECOMPRESSED_TRACE_BYTES,
+) -> bytes:
+  """Decompress gzip-compressed trace data with a hard size bound.
+
+  Zstd payloads are size-checked (via frame header) but returned compressed,
+  since the plugin path serves zstd protobufs as ``application/octet-stream``
+  for frontend/WASM decompression. Uncompressed data is returned as-is.
+
+  Raises:
+    CompressedTraceError: On corrupt or oversize compressed input.
+  """
+  if not data:
+    return data
+  if data.startswith(_GZIP_MAGIC):
+    return _gzip_decompress_bounded(data, max_decompressed_bytes)
+  if data.startswith(_ZSTD_MAGIC):
+    ensure_compressed_trace_within_bounds(data, max_decompressed_bytes)
+    return data
+  return data
+
+
+def _validated_pb_trace_data(raw_data: bytes) -> bytes:
+  """Bounds-check compressed pb trace bytes; raise ValueError on failure."""
+  try:
+    ensure_compressed_trace_within_bounds(raw_data)
+  except CompressedTraceError as exc:
+    raise ValueError(str(exc)) from exc
+  return raw_data
 
 
 def process_raw_trace(raw_trace: bytes) -> str:
@@ -130,7 +323,7 @@ def xspace_to_tool_data(
     raw_data, success = xspace_wrapper_func(xspace_paths, tool, options)
     if success:
       if options.get('format') == 'pb':
-        data = raw_data
+        data = _validated_pb_trace_data(raw_data)
         content_type = 'application/octet-stream'
       else:
         data = process_raw_trace(raw_data)
@@ -140,9 +333,11 @@ def xspace_to_tool_data(
     options['hosts'] = params.get('hosts', [])
     raw_data, success = xspace_wrapper_func(xspace_paths, tool, options)
     if success:
-      data = raw_data
       if options.get('format') == 'pb':
+        data = _validated_pb_trace_data(raw_data)
         content_type = 'application/octet-stream'
+      else:
+        data = raw_data
   elif tool == 'overview_page':
     json_data, success = xspace_wrapper_func(xspace_paths, tool, options)
     if success:

--- a/plugin/xprof/convert/raw_to_tool_data_test.py
+++ b/plugin/xprof/convert/raw_to_tool_data_test.py
@@ -15,6 +15,8 @@
 
 """Tests for the raw_to_tool_data module."""
 
+import gzip
+import struct
 from unittest import mock
 
 from absl.testing import absltest
@@ -26,6 +28,20 @@ from xprof.protobuf import (
     trace_events_old_pb2,
 )
 from xprof.convert import _pywrap_profiler_plugin
+
+
+def _zstd_frame_with_content_size(content_size: int) -> bytes:
+  """Build a minimal zstd frame header declaring ``content_size``.
+
+  Uses Single_Segment + 8-byte Frame_Content_Size so any size fits. The
+  frame body is intentionally incomplete; bounds checks only need the header.
+  """
+  magic = b'\x28\xb5\x2f\xfd'
+  # FCS_flag=3 (8 bytes), Single_Segment=1, no dict id, no checksum.
+  descriptor = bytes([0xE0])
+  fcs = struct.pack('<Q', content_size)
+  # Pad a few bytes so the payload is non-empty after the header.
+  return magic + descriptor + fcs + b'\x00\x01\x02\x03'
 
 
 class RawToToolDataTest(absltest.TestCase):
@@ -348,6 +364,133 @@ class RawToToolDataTest(absltest.TestCase):
         "graph_viewer",
         {"type": "pb", "use_saved_result": True},
     )
+
+
+class CompressedTraceBoundsTest(absltest.TestCase):
+  """Tests for compressed protobuf/gzip size limits and corrupt handling."""
+
+  def test_max_decompressed_trace_bytes_is_positive(self):
+    self.assertGreater(raw_to_tool_data.MAX_DECOMPRESSED_TRACE_BYTES, 0)
+
+  def test_uncompressed_payload_passes_bounds_check(self):
+    # Happy path for mocks / raw protobufs: no gzip/zstd magic → no-op.
+    raw_to_tool_data.ensure_compressed_trace_within_bounds(b"compressed_pb")
+    self.assertEqual(
+        raw_to_tool_data.decompress_trace_data(b"not-compressed"),
+        b"not-compressed",
+    )
+
+  def test_gzip_happy_path_decompresses_under_limit(self):
+    payload = b"trace-event-payload" * 10
+    compressed = gzip.compress(payload)
+    raw_to_tool_data.ensure_compressed_trace_within_bounds(
+        compressed, max_decompressed_bytes=len(payload) + 1
+    )
+    self.assertEqual(
+        raw_to_tool_data.decompress_trace_data(
+            compressed, max_decompressed_bytes=len(payload) + 1
+        ),
+        payload,
+    )
+
+  def test_gzip_corrupt_header_raises(self):
+    corrupt = b"\x1f\x8b" + b"\x00\x00\x00\x00\xff\xff"
+    with self.assertRaisesRegex(
+        raw_to_tool_data.CompressedTraceError, "corrupt gzip"
+    ):
+      raw_to_tool_data.ensure_compressed_trace_within_bounds(corrupt)
+
+  def test_gzip_oversize_raises(self):
+    payload = b"A" * 10_000
+    compressed = gzip.compress(payload)
+    with self.assertRaisesRegex(
+        raw_to_tool_data.CompressedTraceError, "exceeds limit"
+    ):
+      raw_to_tool_data.ensure_compressed_trace_within_bounds(
+          compressed, max_decompressed_bytes=100
+      )
+
+  def test_zstd_happy_path_declared_size_under_limit(self):
+    frame = _zstd_frame_with_content_size(1024)
+    raw_to_tool_data.ensure_compressed_trace_within_bounds(
+        frame, max_decompressed_bytes=1024
+    )
+    # decompress_trace_data size-checks zstd but returns compressed bytes.
+    self.assertEqual(
+        raw_to_tool_data.decompress_trace_data(
+            frame, max_decompressed_bytes=1024
+        ),
+        frame,
+    )
+
+  def test_zstd_corrupt_header_raises(self):
+    # Valid magic, truncated / invalid descriptor payload.
+    corrupt = b"\x28\xb5\x2f\xfd\xff"
+    with self.assertRaisesRegex(
+        raw_to_tool_data.CompressedTraceError, "corrupt zstd"
+    ):
+      raw_to_tool_data.ensure_compressed_trace_within_bounds(corrupt)
+
+  def test_zstd_reserved_bits_raise(self):
+    # Descriptor with reserved bit 3 set.
+    corrupt = b"\x28\xb5\x2f\xfd" + bytes([0x08]) + b"\x00"
+    with self.assertRaisesRegex(
+        raw_to_tool_data.CompressedTraceError, "reserved"
+    ):
+      raw_to_tool_data.ensure_compressed_trace_within_bounds(corrupt)
+
+  def test_zstd_oversize_declared_content_raises(self):
+    oversize = raw_to_tool_data.MAX_DECOMPRESSED_TRACE_BYTES + 1
+    frame = _zstd_frame_with_content_size(oversize)
+    with self.assertRaisesRegex(
+        raw_to_tool_data.CompressedTraceError,
+        r"decompressed zstd trace exceeds limit",
+    ):
+      raw_to_tool_data.ensure_compressed_trace_within_bounds(frame)
+
+  def test_trace_viewer_pb_oversize_zstd_raises_value_error(self):
+    frame = _zstd_frame_with_content_size(
+        raw_to_tool_data.MAX_DECOMPRESSED_TRACE_BYTES + 1
+    )
+    params = {"trace_viewer_options": {"format": "pb"}}
+    wrapper_func = mock.MagicMock(return_value=(frame, True))
+
+    with self.assertRaisesRegex(ValueError, "exceeds limit"):
+      raw_to_tool_data.xspace_to_tool_data(
+          xspace_paths=["/path/to/xspace"],
+          tool="trace_viewer",
+          params=params,
+          xspace_wrapper_func=wrapper_func,
+      )
+
+  def test_trace_viewer_streaming_pb_corrupt_gzip_raises_value_error(self):
+    corrupt = b"\x1f\x8b\x00\x00\x00\x00\xff\xff"
+    params = {"trace_viewer_options": {"format": "pb"}}
+    wrapper_func = mock.MagicMock(return_value=(corrupt, True))
+
+    with self.assertRaisesRegex(ValueError, "corrupt gzip"):
+      raw_to_tool_data.xspace_to_tool_data(
+          xspace_paths=["/path/to/xspace"],
+          tool="trace_viewer@",
+          params=params,
+          xspace_wrapper_func=wrapper_func,
+      )
+
+  def test_trace_viewer_pb_valid_gzip_returns_octet_stream(self):
+    payload = b"ok-trace"
+    compressed = gzip.compress(payload)
+    params = {"trace_viewer_options": {"format": "pb"}}
+    wrapper_func = mock.MagicMock(return_value=(compressed, True))
+
+    data, content_type = raw_to_tool_data.xspace_to_tool_data(
+        xspace_paths=["/path/to/xspace"],
+        tool="trace_viewer",
+        params=params,
+        xspace_wrapper_func=wrapper_func,
+    )
+
+    self.assertEqual(data, compressed)
+    self.assertEqual(content_type, "application/octet-stream")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a hard decompressed-size guard for compressed protobuf traces served by the profile plugin (`format=pb`), addressing decompression-bomb risk from [#2891](https://github.com/openxla/xprof/pull/2891) (FIX-008).

- Introduces `MAX_DECOMPRESSED_TRACE_BYTES` (512 MiB) and `CompressedTraceError`
- Validates **gzip** via streaming decompress under the size cap
- Validates **zstd** via declared `Frame_Content_Size` in the frame header (no new Python zstd dependency; matches C++ producer behavior)
- Wires checks into `trace_viewer` / `trace_viewer@` `format=pb` paths; corrupt/oversize raise clear `ValueError` (HTTP 500 via existing `data_route` handler)
- Happy path for uncompressed / mock payloads unchanged

## Test plan
- [x] Hermetic `raw_to_tool_data_test` suite (29 tests): all existing cases + new `CompressedTraceBoundsTest`
  - corrupt gzip header
  - gzip oversize synthetic stream
  - corrupt zstd header / reserved bits
  - zstd oversize declared content size
  - integration: `xspace_to_tool_data` raises `ValueError` on oversize/corrupt `format=pb`
  - happy path gzip + uncompressed mock `compressed_pb` still returns octet-stream