### PR TITLE
test(trace_viewer_v2): feature flag uniqueness

### DIFF
--- a/frontend/app/components/trace_viewer_v2/feature_flags.ts
+++ b/frontend/app/components/trace_viewer_v2/feature_flags.ts
@@ -15,6 +15,13 @@ export declare interface FeatureFlag {
 /**
  * The list of all available feature flags.
  * Enforced to be unique by design using object keys.
+ *
+ * Policy for experimental / default-off flags:
+ * - Prefer `default: false` until the feature is ready to ship broadly.
+ * - Put an owner and a remove-by date in `description` so flags do not
+ *   linger indefinitely, e.g.:
+ *   "Owner: xprof-team@. Remove-by: 2026-12-01. <what the flag does>"
+ * - Ids and display names (labels) must stay unique; see feature_flags_test.ts.
  */
 const FEATURE_FLAGS = {
   'use_pb': {

--- a/frontend/app/components/trace_viewer_v2/feature_flags_test.ts
+++ b/frontend/app/components/trace_viewer_v2/feature_flags_test.ts
@@ -1,0 +1,59 @@
+import {
+  FeatureFlag,
+  getAllFeatureFlags,
+  getDefaultFeatureFlag,
+  getFeatureFlags,
+} from './feature_flags';
+
+/**
+ * Runtime guards for FEATURE_FLAGS.
+ *
+ * Object keys already enforce unique ids at the TypeScript level. This suite
+ * additionally asserts unique display labels (names) and non-empty metadata so
+ * CI fails if two flags share a UI label or a flag is registered without a
+ * description.
+ */
+describe('FEATURE_FLAGS', () => {
+  let flags: FeatureFlag[];
+
+  beforeEach(() => {
+    flags = getFeatureFlags();
+  });
+
+  it('exposes a non-empty list via getFeatureFlags and getAllFeatureFlags', () => {
+    expect(flags.length).toBeGreaterThan(0);
+    expect(getAllFeatureFlags()).toEqual(flags);
+  });
+
+  it('has unique ids', () => {
+    const ids = flags.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('has unique display names (labels)', () => {
+    const names = flags.map((f) => f.name);
+    const duplicates = names.filter(
+      (name, index) => names.indexOf(name) !== index,
+    );
+    expect(duplicates).toEqual([]);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('has non-empty ids, names, and descriptions', () => {
+    for (const flag of flags) {
+      expect(flag.id.trim().length > 0).toBe(true);
+      expect(flag.name.trim().length > 0).toBe(true);
+      expect(flag.description.trim().length > 0).toBe(true);
+    }
+  });
+
+  it('returns the registered default for known ids', () => {
+    for (const flag of flags) {
+      expect(getDefaultFeatureFlag(flag.id)).toBe(flag.default);
+    }
+  });
+
+  it('defaults unknown flag ids to false', () => {
+    expect(getDefaultFeatureFlag('__not_a_real_feature_flag__')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds runtime uniqueness coverage for Trace Viewer v2 `FEATURE_FLAGS` so CI catches duplicate display labels / empty metadata that TypeScript object keys alone do not prevent.

Object keys already guarantee unique **ids** at build time (#2733). This PR adds `feature_flags_test.ts` (already listed on the `:tests` `ts_library`) asserting:

- unique ids
- unique display names (labels) — fails if two flags share a UI label
- non-empty ids, names, and descriptions
- `getDefaultFeatureFlag` matches registered defaults; unknown ids default to `false`
- `getFeatureFlags` / `getAllFeatureFlags` agree

Also documents the experimental-flag policy (prefer default-off; owner + remove-by date in `description`) on `FEATURE_FLAGS`.

### Fixes
- **FIX-012**: FEATURE_FLAGS uniqueness CI assert (#2733 / #2796)

## Test plan
- [x] Local Node uniqueness mirror of the Jasmine suite (unique ids/labels, non-empty metadata) — all 4 registered flags OK
- [x] `feature_flags_test.ts` wired via existing `//frontend/app/components/trace_viewer_v2:tests` `ts_library` srcs
- [ ] Jasmine suite execution under internal/google3 test runner (OSS tree has no `jasmine_node_test` target for this package)