### PR TITLE
test(convert): document GPU FlatOp path and empty source-info helpers

### DIFF
--- a/xprof/convert/BUILD
+++ b/xprof/convert/BUILD
@@ -3060,6 +3060,7 @@ cc_test(
     deps = [
         ":xplane_to_flat_op_metrics_db",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@org_xprof//plugin/xprof/protobuf:flat_op_metrics_proto_cc",

--- a/xprof/convert/xplane_to_flat_op_metrics_db.h
+++ b/xprof/convert/xplane_to_flat_op_metrics_db.h
@@ -37,6 +37,12 @@ FlatOpMetricsDb ConvertTensorCoreDeviceTraceXPlaneToFlatOpMetricsDb(
     const absl::flat_hash_map<std::pair<uint64_t, uint64_t>, FlatOpMetricsDb>&
         sparse_core_metrics_map);
 
+// Native GPU device-trace path: parse a GPU XPlane into FlatOpMetricsDb using
+// DeviceFlatOpMetricsDbBuilder (aggregates XLA HLO ops via hlo_module_map and
+// TF ops via GpuEventStats). Owned exclusively by ConvertXSpaceToFlatOpMetricsDb
+// when device planes are GPU (not TPU tensor-core / sparse-core converters).
+// Do not also feed the same GPU plane through the TPU converters — that would
+// double-count events in the combined FlatOpMetricsDb.
 FlatOpMetricsDb ConvertDeviceTraceXPlaneToFlatOpMetricsDb(
     const XPlane& device_trace, const HloModuleMap& hlo_module_map);
 

--- a/xprof/convert/xplane_to_flat_op_metrics_db_test.cc
+++ b/xprof/convert/xplane_to_flat_op_metrics_db_test.cc
@@ -21,15 +21,17 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "testing/base/public/gmock.h"
-#include "<gtest/gtest.h>"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "xla/tsl/profiler/utils/xplane_schema.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 #include "xprof/convert/xplane_to_op_metrics_db.h"
 #include "plugin/xprof/protobuf/flat_op_metrics.pb.h"
 #include "plugin/xprof/protobuf/op_metrics.pb.h"
+#include "xprof/utils/flat_op_metrics_db_utils.h"
 #include "xprof/utils/hlo_module_map.h"
 
 namespace tensorflow {
@@ -654,6 +656,99 @@ TEST_F(XPlaneToFlatOpMetricsDbTest, GpuEquivalenceTest) {
   EXPECT_EQ(legacy_db.metrics_db_size(), new_db.op_instances_size());
   EXPECT_EQ(legacy_db.total_op_time_ps(), new_db.total_op_time_ps());
   EXPECT_EQ(legacy_db.total_time_ps(), new_db.total_time_ps());
+
+  // No double registration: each op name appears exactly once in the flat DB.
+  absl::flat_hash_set<std::string> seen_names;
+  for (const auto& op : new_db.op_instances()) {
+    EXPECT_TRUE(seen_names.insert(op.hlo_name()).second)
+        << "Duplicate FlatOpMetrics registration for: " << op.hlo_name();
+  }
+}
+
+// Synthetic GPU stream with only TF ops (empty HloModuleMap): documents
+// expected occurrence/time counts for the sole GPU FlatOp path and asserts
+// that the same events are not double-counted under a second conversion.
+// GpuEventStats reads kTfOp from *event* stats (not event metadata).
+TEST_F(XPlaneToFlatOpMetricsDbTest, GpuSyntheticTfOpsSinglePathCounts) {
+  XLineBuilder stream = plane_builder_->GetOrCreateLine(1);
+  stream.SetName("Stream #0");
+
+  // Op A: 1000–1500 ns (500 ns = 500000 ps)
+  XEventBuilder op_a =
+      stream.AddEvent(*plane_builder_->GetOrCreateEventMetadata("kernel_a"));
+  op_a.SetTimestampNs(1000);
+  op_a.SetDurationNs(500);
+  op_a.AddStatValue(*plane_builder_->GetOrCreateStatMetadata(
+                        GetStatTypeStr(StatType::kDeviceOffsetPs)),
+                    int64_t{1000000});
+  op_a.AddStatValue(*plane_builder_->GetOrCreateStatMetadata(
+                        GetStatTypeStr(StatType::kDeviceDurationPs)),
+                    int64_t{500000});
+  // TF op fullname format is "name:type" (see ParseTfOpFullname).
+  op_a.AddStatValue(
+      *plane_builder_->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kTfOp)),
+      "layer/MatMul:MatMul");
+
+  // Op B: 2000–2600 ns (600 ns = 600000 ps), non-overlapping with A.
+  XEventBuilder op_b =
+      stream.AddEvent(*plane_builder_->GetOrCreateEventMetadata("kernel_b"));
+  op_b.SetTimestampNs(2000);
+  op_b.SetDurationNs(600);
+  op_b.AddStatValue(*plane_builder_->GetOrCreateStatMetadata(
+                        GetStatTypeStr(StatType::kDeviceOffsetPs)),
+                    int64_t{2000000});
+  op_b.AddStatValue(*plane_builder_->GetOrCreateStatMetadata(
+                        GetStatTypeStr(StatType::kDeviceDurationPs)),
+                    int64_t{600000});
+  op_b.AddStatValue(
+      *plane_builder_->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kTfOp)),
+      "layer/Conv2D:Conv2D");
+
+  HloModuleMap empty_hlo_module_map;
+  FlatOpMetricsDb first =
+      ConvertDeviceTraceXPlaneToFlatOpMetricsDb(*xplane_, empty_hlo_module_map);
+  FlatOpMetricsDb second =
+      ConvertDeviceTraceXPlaneToFlatOpMetricsDb(*xplane_, empty_hlo_module_map);
+
+  // IDLE + two TF ops. Flat names are "tf_op_name/event_name".
+  ASSERT_EQ(first.op_instances_size(), 3);
+  absl::flat_hash_map<std::string, const FlatOpMetrics*> by_name;
+  for (const auto& op : first.op_instances()) {
+    by_name[op.hlo_name()] = &op;
+  }
+  ASSERT_EQ(by_name.size(), 3) << "expected unique op names (no double-count)";
+
+  ASSERT_TRUE(by_name.contains("layer/MatMul/kernel_a"));
+  EXPECT_EQ(by_name["layer/MatMul/kernel_a"]->occurrences(), 1);
+  EXPECT_EQ(by_name["layer/MatMul/kernel_a"]->time_ps(), 500000);
+  EXPECT_EQ(by_name["layer/MatMul/kernel_a"]->category(), "MatMul");
+
+  ASSERT_TRUE(by_name.contains("layer/Conv2D/kernel_b"));
+  EXPECT_EQ(by_name["layer/Conv2D/kernel_b"]->occurrences(), 1);
+  EXPECT_EQ(by_name["layer/Conv2D/kernel_b"]->time_ps(), 600000);
+  EXPECT_EQ(by_name["layer/Conv2D/kernel_b"]->category(), "Conv2D");
+
+  // Total span 1000–2600 ns → 1.6e6 ps; total op time 1.1e6 ps.
+  EXPECT_EQ(first.total_op_time_ps(), 1100000);
+  EXPECT_EQ(first.total_time_ps(), 1600000);
+
+  // Re-running the same sole GPU converter is deterministic (same counts).
+  EXPECT_EQ(first.op_instances_size(), second.op_instances_size());
+  EXPECT_EQ(first.total_op_time_ps(), second.total_op_time_ps());
+  EXPECT_EQ(first.total_time_ps(), second.total_time_ps());
+}
+
+// Empty GPU plane + empty HloModuleMap: helpers return idle-only DB without
+// crash (contract for missing module / empty device trace).
+TEST_F(XPlaneToFlatOpMetricsDbTest, GpuEmptyPlaneEmptyModuleMap) {
+  HloModuleMap empty_hlo_module_map;
+  FlatOpMetricsDb db =
+      ConvertDeviceTraceXPlaneToFlatOpMetricsDb(*xplane_, empty_hlo_module_map);
+  // Only the synthetic idle op when there are no device events.
+  ASSERT_EQ(db.op_instances_size(), 1);
+  EXPECT_EQ(db.op_instances(0).category(), kIdle);
+  EXPECT_EQ(db.total_time_ps(), 0);
+  EXPECT_EQ(db.total_op_time_ps(), 0);
 }
 
 }  // namespace

--- a/xprof/convert/xplane_to_op_stats.cc
+++ b/xprof/convert/xplane_to_op_stats.cc
@@ -816,15 +816,19 @@ absl::StatusOr<OpStats> ConvertXSpaceToFlatOpMetricsDb(
   // KernelReportMap reports;
 
   // Handle device planes first. device_planes will contain either GPU or TPU.
+  // Call-path ownership for FlatOpMetricsDb (single converter per plane — do
+  // not also run the legacy OpMetricsDb GPU path into the same flat DB):
+  //   * TPU tensor-core planes →
+  //       ConvertTensorCoreDeviceTraceXPlaneToFlatOpMetricsDb
+  //       (sparse-core planes first via
+  //        ConvertSparseCoreDeviceTraceXPlaneToFlatOpMetricsDb)
+  //   * GPU device planes → ConvertDeviceTraceXPlaneToFlatOpMetricsDb
+  //       (native GPU XPlane → FlatOpMetricsDb via DeviceFlatOpMetricsDbBuilder)
   std::vector<const XPlane*> device_planes =
       FindPlanesWithPrefix(space, kTpuPlanePrefix);
   const bool is_gpu = device_planes.empty();
   if (is_gpu) {
     device_planes = FindPlanesWithPrefix(space, kGpuPlanePrefix);
-    if (!device_planes.empty()) {
-      return absl::UnimplementedError(
-          "GPU not supported yet for FlatOpMetricsDb");
-    }
   }
   const bool is_tpu = !is_gpu;
   std::string hostname = Hostname(space);
@@ -908,10 +912,20 @@ absl::StatusOr<OpStats> ConvertXSpaceToFlatOpMetricsDb(
         // Safe to capture sparse_core_metrics_map by reference
         // as it is accessed as read-only in threads. All
         // modifications were completed sequentially on the main thread.
+        // Exactly one converter owns each plane: TPU tensor-core vs GPU
+        // ConvertDeviceTrace — never both for the same events.
         executor->Execute([device_plane, &op_metrics_db,
-                           &sparse_core_metrics_map]() {
-          op_metrics_db = ConvertTensorCoreDeviceTraceXPlaneToFlatOpMetricsDb(
-              *device_plane, sparse_core_metrics_map);
+                           &sparse_core_metrics_map, is_tpu,
+                           &hlo_module_map]() {
+          if (is_tpu) {
+            op_metrics_db = ConvertTensorCoreDeviceTraceXPlaneToFlatOpMetricsDb(
+                *device_plane, sparse_core_metrics_map);
+          } else {
+            // GPU: ConvertDeviceTraceXPlaneToFlatOpMetricsDb is the sole
+            // FlatOpMetricsDb producer for this plane (see #2840).
+            op_metrics_db = ConvertDeviceTraceXPlaneToFlatOpMetricsDb(
+                *device_plane, hlo_module_map);
+          }
         });
       }
     }

--- a/xprof/utils/flat_op_metrics_db_utils_test.cc
+++ b/xprof/utils/flat_op_metrics_db_utils_test.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "<gtest/gtest.h>"
+#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "xla/tsl/profiler/utils/xplane_schema.h"
@@ -715,6 +715,86 @@ TEST_F(XEventsFlatOpMetricsDbBuilderTest, SourceInformationParsing) {
   EXPECT_EQ(metric.source_info().file_name(), "filename.cc");
   EXPECT_EQ(metric.source_info().line_number(), 123);
   EXPECT_EQ(metric.source_info().stack_frame(), "stack_frame_contents");
+}
+
+// Empty / malformed source helpers used by roofline FlatOpMetric path (#2898):
+// must not crash; file_name/line stay empty when parse fails.
+TEST_F(XEventsFlatOpMetricsDbBuilderTest, EmptyAndMalformedSourceInfoHelpers) {
+  auto run_with_source = [this](absl::string_view op_name,
+                                absl::string_view source_value) {
+    XPlane plane = CreateTestXPlane();
+    XPlaneBuilder plane_builder(&plane);
+    XLineBuilder line_builder = plane_builder.GetOrCreateLine(0);
+    CreateXEvent(plane_builder, line_builder, op_name, 1000, 500, 1, 1);
+    XEventMetadata* meta = plane_builder.GetOrCreateEventMetadata(op_name);
+    XStatMetadata* source_meta =
+        plane_builder.GetOrCreateStatMetadata("source");
+    auto* stat_source = meta->add_stats();
+    stat_source->set_metadata_id(source_meta->id());
+    stat_source->set_str_value(std::string(source_value));
+
+    XPlaneVisitor plane_visitor(&plane, {}, {tsl::profiler::FindStatType});
+    XEventVisitor event_visitor(&plane_visitor, &plane.lines(0),
+                                &plane.lines(0).events(0));
+    XEventsFlatOpMetricsDbBuilder local_builder;
+    local_builder.AddOpMetric(event_visitor);
+    return local_builder.Finalize();
+  };
+
+  // Empty source string: silent failure, empty source_info fields.
+  {
+    FlatOpMetricsDb db = run_with_source("op_empty_source", "");
+    ASSERT_EQ(db.op_instances_size(), 1);
+    const auto& metric = db.op_instances(0);
+    EXPECT_TRUE(metric.source_info().file_name().empty());
+    EXPECT_EQ(metric.source_info().line_number(), 0);
+  }
+
+  // Missing colon (not "file:line"): silent failure without crash.
+  {
+    FlatOpMetricsDb db = run_with_source("op_no_colon", "filename_only.cc");
+    ASSERT_EQ(db.op_instances_size(), 1);
+    const auto& metric = db.op_instances(0);
+    EXPECT_TRUE(metric.source_info().file_name().empty());
+    EXPECT_EQ(metric.source_info().line_number(), 0);
+  }
+
+  // Non-numeric line after colon.
+  {
+    FlatOpMetricsDb db = run_with_source("op_bad_line", "filename.cc:not_a_line");
+    ASSERT_EQ(db.op_instances_size(), 1);
+    const auto& metric = db.op_instances(0);
+    EXPECT_TRUE(metric.source_info().file_name().empty());
+    EXPECT_EQ(metric.source_info().line_number(), 0);
+  }
+
+  // Empty module-style stack only: source stack may be set without file:line.
+  {
+    XPlane plane = CreateTestXPlane();
+    XPlaneBuilder plane_builder(&plane);
+    XLineBuilder line_builder = plane_builder.GetOrCreateLine(0);
+    CreateXEvent(plane_builder, line_builder, "op_empty_module_stack", 1000, 500,
+                 1, 1);
+    XEventMetadata* meta =
+        plane_builder.GetOrCreateEventMetadata("op_empty_module_stack");
+    XStatMetadata* stack_meta =
+        plane_builder.GetOrCreateStatMetadata("source_stack");
+    auto* stat_stack = meta->add_stats();
+    stat_stack->set_metadata_id(stack_meta->id());
+    stat_stack->set_str_value("<embedded module '_launcher'>");
+
+    XPlaneVisitor plane_visitor(&plane, {}, {tsl::profiler::FindStatType});
+    XEventVisitor event_visitor(&plane_visitor, &plane.lines(0),
+                                &plane.lines(0).events(0));
+    builder_->AddOpMetric(event_visitor);
+    FlatOpMetricsDb db = builder_->Finalize();
+    ASSERT_EQ(db.op_instances_size(), 1);
+    const auto& metric = db.op_instances(0);
+    ASSERT_TRUE(metric.has_source_info());
+    EXPECT_TRUE(metric.source_info().file_name().empty());
+    EXPECT_EQ(metric.source_info().stack_frame(),
+              "<embedded module '_launcher'>");
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- Restore and document the GPU FlatOpMetricsDb call path in `ConvertXSpaceToFlatOpMetricsDb`: GPU planes use `ConvertDeviceTraceXPlaneToFlatOpMetricsDb` exclusively (TPU uses tensor-core / sparse-core converters). The GPU routing was accidentally dropped by an unrelated duty-cycle revert.
- Add synthetic GPU unit tests with exact TF-op occurrence/time counts and unique-name (no double-registration) asserts; empty plane + empty HloModuleMap returns IDLE-only without crash.
- Add empty/malformed source-info helper coverage for the FlatOp roofline path (`PopulateSourceInfo` via event stats): empty string, missing colon, non-numeric line, and stack-only empty module frame.

## Context
Critique follow-ups FIX-010 (#2840) and FIX-027 (#2898).

## Test plan
- [x] `bazel test //xprof/convert:xplane_to_flat_op_metrics_db_test //xprof/utils:flat_op_metrics_db_utils_test --config=clang_local` (macOS) — all PASSED