### PR TITLE
fix(trace_viewer): clear network dedup caches on run/host change

### DIFF
--- a/frontend/app/components/trace_viewer/trace_viewer.ts
+++ b/frontend/app/components/trace_viewer/trace_viewer.ts
@@ -82,9 +82,13 @@ import {
   TraceFilters,
 } from './trace_viewer_typings';
 import {
+  buildAdjacentNodesCacheKey,
+  buildEventArgsCacheKey,
+  buildNetworkCacheScope,
   getProcessMappingsFromWasm,
   getProcessNamesFromWasm,
   parseEventsSelectedData,
+  shouldInvalidateNetworkCache,
 } from './utils';
 
 interface TraceData {
@@ -199,12 +203,20 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
 
   selectionStartFormat?: string;
   selectionExtentFormat?: string;
+  /**
+   * Network request dedup caches for lazy event-args and adjacent-node fetches.
+   * Keys omit run/host; {@link clearNetworkDedupCaches} must run whenever the
+   * navigation scope (run / tag / host) changes so a prior profile cannot
+   * serve stale args. In-flight responses also re-check scope before writing.
+   */
   private readonly eventArgsCache = new Map<string, Record<string, string>>();
   private readonly hloAdjacentNodesCache = new Map<
     string,
     AdjacentNodesResponse
   >();
   private readonly pendingAdjacentNodesFetches = new Set<string>();
+  /** Last run|tag|host scope used for the network dedup caches above. */
+  private lastNetworkCacheScope: string | null = null;
   private queryString = '';
   searching = false;
   private readonly searchQuery = new ReplaySubject<string>(1);
@@ -536,6 +548,10 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
   }
 
   update(event: NavigationEvent): void {
+    // Drop deduped network results when the profile scope changes so event-arg
+    // and adjacent-node caches cannot return data from a previous run/host.
+    this.maybeInvalidateNetworkCaches(event);
+
     const isStreaming = event.tag === 'trace_viewer@';
     const run = event.run || '';
     const tag = event.tag || '';
@@ -670,6 +686,43 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
       }
     }
     return event.host || (this.hostList && this.hostList[0]) || '';
+  }
+
+  /**
+   * Composes the navigation scope used to decide when network dedup caches
+   * must be cleared. Mirrors the (run, tag, host) triple passed to
+   * DataServiceV2.getData for event-args and adjacent-node fetches.
+   */
+  private getNetworkCacheScope(
+    event: NavigationEvent = this.navigationEvent,
+  ): string {
+    return buildNetworkCacheScope(
+      event.run ?? '',
+      event.tag ?? '',
+      this.getCurrentHost(event),
+    );
+  }
+
+  /**
+   * Clears event-args / adjacent-node dedup state. Exposed for tests via the
+   * package suite; production callers go through maybeInvalidateNetworkCaches.
+   */
+  clearNetworkDedupCaches(): void {
+    this.eventArgsCache.clear();
+    this.hloAdjacentNodesCache.clear();
+    this.pendingAdjacentNodesFetches.clear();
+  }
+
+  /**
+   * Invalidates network dedup caches when run, tag, or host changes. The first
+   * observation of a scope only records it (no clear).
+   */
+  private maybeInvalidateNetworkCaches(event: NavigationEvent): void {
+    const nextScope = this.getNetworkCacheScope(event);
+    if (shouldInvalidateNetworkCache(this.lastNetworkCacheScope, nextScope)) {
+      this.clearNetworkDedupCaches();
+    }
+    this.lastNetworkCacheScope = nextScope;
   }
 
   // START Trace Viewer V2 WASM App Methods
@@ -842,7 +895,7 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    const cacheKey = `${name}:${startUs}`;
+    const cacheKey = buildEventArgsCacheKey(name, startUs);
 
     const params = new Map<string, string>();
     params.set('event_name', name);
@@ -865,6 +918,11 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
       host = this.getCurrentHost();
     }
 
+    // Capture navigation scope at request time so a late response after a
+    // run/host/tag change neither pollutes the cleared cache nor mutates the
+    // wrong selection. Scope uses getCurrentHost(), not the pid-resolved host.
+    const requestScope = this.getNetworkCacheScope();
+
     this.dataService
       .getData(
         this.navigationEvent.run ?? '',
@@ -874,6 +932,9 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
       )
       .pipe(takeUntil(this.destroyed))
       .subscribe((data) => {
+        if (this.getNetworkCacheScope() !== requestScope) {
+          return;
+        }
         const traceData = data as TraceData;
         if (
           !traceData ||
@@ -917,7 +978,7 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
     const {name, module} = getHloNameAndModule(this.selectedEventProperties);
     if (!name || !module) return;
 
-    const key = `${name}-${module}`;
+    const key = buildAdjacentNodesCacheKey(name, module);
     const cachedAdjNodes = this.hloAdjacentNodesCache.get(key);
     if (cachedAdjNodes) {
       this.injectAdjacentNodes({
@@ -936,11 +997,14 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
     params.set('node_name', name);
     params.set('module_name', module);
 
+    const host = this.getCurrentHost();
+    const requestScope = this.getNetworkCacheScope();
+
     this.dataService
       .getData(
         this.navigationEvent.run ?? '',
         'graph_viewer',
-        this.getCurrentHost(),
+        host,
         params,
       )
       .pipe(
@@ -950,6 +1014,10 @@ export class TraceViewer implements OnInit, AfterViewInit, OnDestroy {
         }),
       )
       .subscribe((data) => {
+        // Discard responses that raced a run/host/tag navigation change.
+        if (this.getNetworkCacheScope() !== requestScope) {
+          return;
+        }
         if (isAdjacentNodesResponse(data)) {
           this.hloAdjacentNodesCache.set(key, data);
           this.injectAdjacentNodes({

--- a/frontend/app/components/trace_viewer/utils.ts
+++ b/frontend/app/components/trace_viewer/utils.ts
@@ -210,3 +210,43 @@ export function getProcessNamesFromWasm(
   }
   return result;
 }
+
+/**
+ * Scope identity for Trace Viewer network dedup caches (event args + adjacent
+ * HLO nodes). Keys deliberately exclude run/host so lookups stay short; instead
+ * callers clear the maps whenever this scope string changes.
+ */
+export function buildNetworkCacheScope(
+  run: string,
+  tag: string,
+  host: string,
+): string {
+  return `${run}|${tag}|${host}`;
+}
+
+/**
+ * Cache key for lazy event-arg fetches. Start time is in microseconds; the
+ * fetch path also tolerates a 50ms fuzzy match when scanning the map.
+ */
+export function buildEventArgsCacheKey(name: string, startUs: number): string {
+  return `${name}:${startUs}`;
+}
+
+/** Cache key for HLO adjacent-node (operands/consumers) fetches. */
+export function buildAdjacentNodesCacheKey(
+  nodeName: string,
+  moduleName: string,
+): string {
+  return `${nodeName}-${moduleName}`;
+}
+
+/**
+ * True when a prior scope was recorded and the navigation scope changed.
+ * First observation (previous === null) must not clear caches.
+ */
+export function shouldInvalidateNetworkCache(
+  previousScope: string | null,
+  nextScope: string,
+): boolean {
+  return previousScope !== null && previousScope !== nextScope;
+}

--- a/frontend/app/components/trace_viewer/utils_test.ts
+++ b/frontend/app/components/trace_viewer/utils_test.ts
@@ -1,0 +1,94 @@
+import {
+  buildAdjacentNodesCacheKey,
+  buildEventArgsCacheKey,
+  buildNetworkCacheScope,
+  shouldInvalidateNetworkCache,
+} from './utils';
+
+/**
+ * Unit tests for Trace Viewer network-dedup key composition and scope
+ * invalidation (FIX-015 / PR #2814 follow-up).
+ *
+ * Caches store entries under short event keys (no run/host). Callers clear the
+ * maps when {@link buildNetworkCacheScope} changes so a prior profile cannot
+ * serve stale event args or adjacent nodes.
+ */
+describe('trace_viewer network dedup cache keys', () => {
+  describe('buildNetworkCacheScope', () => {
+    it('joins run, tag, and host with | separators', () => {
+      expect(buildNetworkCacheScope('runA', 'trace_viewer', 'host1')).toBe(
+        'runA|trace_viewer|host1',
+      );
+    });
+
+    it('preserves empty fields so missing host still changes scope', () => {
+      expect(buildNetworkCacheScope('runA', 'tag', '')).toBe('runA|tag|');
+      expect(buildNetworkCacheScope('', '', '')).toBe('||');
+    });
+
+    it('differs when only run changes', () => {
+      const a = buildNetworkCacheScope('runA', 'tag', 'host');
+      const b = buildNetworkCacheScope('runB', 'tag', 'host');
+      expect(a).not.toBe(b);
+    });
+
+    it('differs when only host changes', () => {
+      const a = buildNetworkCacheScope('run', 'tag', 'hostA');
+      const b = buildNetworkCacheScope('run', 'tag', 'hostB');
+      expect(a).not.toBe(b);
+    });
+
+    it('differs when only tag/tool changes', () => {
+      const a = buildNetworkCacheScope('run', 'trace_viewer', 'host');
+      const b = buildNetworkCacheScope('run', 'trace_viewer@', 'host');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('buildEventArgsCacheKey', () => {
+    it('composes name:startUs', () => {
+      expect(buildEventArgsCacheKey('op.fusion', 12345000)).toBe(
+        'op.fusion:12345000',
+      );
+    });
+
+    it('does not embed run/host (invalidation is scope-based)', () => {
+      const key = buildEventArgsCacheKey('same', 1);
+      expect(key.includes('|')).toBe(false);
+      expect(key).toBe('same:1');
+    });
+  });
+
+  describe('buildAdjacentNodesCacheKey', () => {
+    it('composes nodeName-moduleName', () => {
+      expect(buildAdjacentNodesCacheKey('%fusion.1', 'module_main')).toBe(
+        '%fusion.1-module_main',
+      );
+    });
+  });
+
+  describe('shouldInvalidateNetworkCache', () => {
+    it('does not invalidate on the first scope observation', () => {
+      expect(
+        shouldInvalidateNetworkCache(null, 'runA|tag|host'),
+      ).toBe(false);
+    });
+
+    it('does not invalidate when scope is unchanged', () => {
+      const scope = buildNetworkCacheScope('run', 'tag', 'host');
+      expect(shouldInvalidateNetworkCache(scope, scope)).toBe(false);
+    });
+
+    it('invalidates when run changes (acceptance: changing run clears cache)', () => {
+      const prev = buildNetworkCacheScope('runA', 'tag', 'host');
+      const next = buildNetworkCacheScope('runB', 'tag', 'host');
+      expect(shouldInvalidateNetworkCache(prev, next)).toBe(true);
+    });
+
+    it('invalidates when host changes', () => {
+      const prev = buildNetworkCacheScope('run', 'tag', 'hostA');
+      const next = buildNetworkCacheScope('run', 'tag', 'hostB');
+      expect(shouldInvalidateNetworkCache(prev, next)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #2814 (event-arg / adjacent-node request dedup): those caches key only by event identity (`name:startUs`, `node-module`) and did not invalidate when the user navigated to another run or host. Stale args from a previous profile could be shown for matching event names.

- Clear `eventArgsCache`, `hloAdjacentNodesCache`, and `pendingAdjacentNodesFetches` when the navigation scope (`run|tag|host`) changes in `update()`
- Discard in-flight responses that race a scope change so they cannot repopulate the cleared maps
- Extract pure key/scope helpers in `utils.ts` and unit-test composition + invalidation rules (`utils_test.ts`; already listed on `:tests`)

## Test plan
- [x] Node smoke: scope change clears maps; same scope keeps entries; key composition assertions
- [x] Jasmine `utils_test.ts` added (package `:tests` already listed it; google3 jasmine harness)
- [ ] Manual: open Trace Viewer V2, select an event with lazy args, switch run/host, reselect similarly-named event → network fetch occurs (no stale args)