### PR TITLE
fix(data_service_v2): version createToolUrl deep-link schema (v=1)

### DIFF
--- a/frontend/app/services/data_service_v2/data_service_v2.ts
+++ b/frontend/app/services/data_service_v2/data_service_v2.ts
@@ -40,6 +40,123 @@ import {Observable, of} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {windowOpen} from 'safevalues/dom';
 
+/**
+ * Deep-link query schema version for {@link DataServiceV2.createToolUrl}.
+ * Bump when the set or meaning of tool-link query params changes.
+ */
+export const TOOL_URL_SCHEMA_VERSION = 1;
+
+/** Query parameter name for the tool URL schema version. */
+export const TOOL_URL_VERSION_PARAM = 'v';
+
+/** Reserved keys not treated as tool-specific params in a tool deep link. */
+const TOOL_URL_RESERVED_KEYS = new Set([
+  'tool',
+  'run',
+  'session_path',
+  'run_path',
+  TOOL_URL_VERSION_PARAM,
+]);
+
+/** Parsed createToolUrl-style deep link. */
+export interface ParsedToolUrl {
+  /** Schema version; missing `v` is treated as 1 for old bookmarks. */
+  schemaVersion: number;
+  toolName: string;
+  sessionId: string;
+  sessionPath: string;
+  runPath: string;
+  /** Tool-specific params (everything except reserved keys). */
+  params: Record<string, string>;
+}
+
+/**
+ * Builds URLSearchParams for a versioned tool deep link.
+ * Always sets `v=<TOOL_URL_SCHEMA_VERSION>`.
+ */
+export function buildToolUrlSearchParams(options: {
+  toolName: string;
+  sessionId: string;
+  params: Record<string, string>;
+  sessionPath?: string | null;
+  runPath?: string | null;
+}): URLSearchParams {
+  const linkParams = new URLSearchParams();
+  // Version first so bookmarks and logs show schema intent clearly.
+  linkParams.set(TOOL_URL_VERSION_PARAM, String(TOOL_URL_SCHEMA_VERSION));
+  linkParams.set('tool', options.toolName);
+  linkParams.set('run', options.sessionId);
+  for (const [key, value] of Object.entries(options.params)) {
+    if (value) {
+      linkParams.set(key, value);
+    }
+  }
+  if (options.sessionPath) {
+    linkParams.set('session_path', options.sessionPath);
+  }
+  if (options.runPath) {
+    linkParams.set('run_path', options.runPath);
+  }
+  return linkParams;
+}
+
+/**
+ * Parses createToolUrl-style deep-link query params.
+ *
+ * Missing or empty `v` is treated as schema version 1 so pre-versioned
+ * bookmarks keep working (FIX-013).
+ */
+export function parseToolUrlSearchParams(
+  searchParams: URLSearchParams | string,
+): ParsedToolUrl {
+  const params =
+    typeof searchParams === 'string'
+      ? new URLSearchParams(
+          searchParams.startsWith('?') ? searchParams.slice(1) : searchParams,
+        )
+      : searchParams;
+
+  const rawVersion = params.get(TOOL_URL_VERSION_PARAM);
+  // Compat: absent `v` means the original (v1) schema.
+  let schemaVersion = 1;
+  if (rawVersion != null && rawVersion !== '') {
+    const parsed = Number(rawVersion);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      schemaVersion = parsed;
+    }
+  }
+
+  const toolParams: Record<string, string> = {};
+  params.forEach((value, key) => {
+    if (!TOOL_URL_RESERVED_KEYS.has(key)) {
+      toolParams[key] = value;
+    }
+  });
+
+  return {
+    schemaVersion,
+    toolName: params.get('tool') ?? '',
+    sessionId: params.get('run') ?? '',
+    sessionPath: params.get('session_path') ?? '',
+    runPath: params.get('run_path') ?? '',
+    params: toolParams,
+  };
+}
+
+/**
+ * Parses a full tool deep-link URL (as produced by createToolUrl) or a
+ * raw query string. Used by tests and any consumer that receives a full href.
+ */
+export function parseToolUrl(urlOrSearch: string): ParsedToolUrl {
+  let search = urlOrSearch;
+  const q = urlOrSearch.indexOf('?');
+  if (q !== -1) {
+    const hash = urlOrSearch.indexOf('#', q);
+    search = hash === -1 ? urlOrSearch.slice(q + 1) : urlOrSearch.slice(q + 1, hash);
+  }
+  return parseToolUrlSearchParams(search);
+}
+
 /** The data service class that calls API and return response. */
 @Injectable()
 export class DataServiceV2 implements DataServiceV2Interface {
@@ -309,23 +426,14 @@ export class DataServiceV2 implements DataServiceV2Interface {
     params: Record<string, string>;
   }): string {
     if (!sessionId) return '';
-    const linkParams = new URLSearchParams();
-    linkParams.set('tool', toolName);
-    linkParams.set('run', sessionId);
-    for (const [key, value] of Object.entries(params)) {
-      if (value) {
-        linkParams.set(key, value);
-      }
-    }
     const searchParams = this.getSearchParams();
-    const sessionPath = searchParams.get('session_path');
-    const runPath = searchParams.get('run_path');
-    if (sessionPath) {
-      linkParams.set('session_path', sessionPath);
-    }
-    if (runPath) {
-      linkParams.set('run_path', runPath);
-    }
+    const linkParams = buildToolUrlSearchParams({
+      toolName,
+      sessionId,
+      params,
+      sessionPath: searchParams.get('session_path'),
+      runPath: searchParams.get('run_path'),
+    });
     return `${window.parent.location.origin}?${linkParams.toString()}#profile`;
   }
 

--- a/frontend/app/services/data_service_v2/data_service_v2_interface.ts
+++ b/frontend/app/services/data_service_v2/data_service_v2_interface.ts
@@ -44,7 +44,13 @@ export interface DataServiceV2Interface {
   // Returns a string of comma separated module names.
   getModuleList(sessionId: string, graphType?: string): Observable<string>;
 
-  /** Creates a tool URL for cross tool linking. */
+  /**
+   * Creates a tool URL for cross tool linking.
+   *
+   * Deep links include `v=1` (query schema version). Consumers parsing these
+   * URLs must treat a missing `v` as version 1 so older bookmarks still work.
+   * See {@code buildToolUrlSearchParams} / {@code parseToolUrlSearchParams}.
+   */
   createToolUrl(options: {
     toolName: string;
     sessionId: string;

--- a/frontend/app/services/data_service_v2/data_service_v2_test.ts
+++ b/frontend/app/services/data_service_v2/data_service_v2_test.ts
@@ -1,0 +1,140 @@
+import {
+  TOOL_URL_SCHEMA_VERSION,
+  TOOL_URL_VERSION_PARAM,
+  buildToolUrlSearchParams,
+  parseToolUrl,
+  parseToolUrlSearchParams,
+} from './data_service_v2';
+
+/**
+ * Unit tests for createToolUrl deep-link schema versioning (FIX-013 / #2899).
+ *
+ * New links emit `v=1`. Parsers accept missing `v` as schema version 1 so
+ * pre-versioned bookmarks keep working.
+ */
+describe('createToolUrl deep-link schema version', () => {
+  describe('buildToolUrlSearchParams', () => {
+    it('always sets v to the current schema version', () => {
+      const params = buildToolUrlSearchParams({
+        toolName: 'graph_viewer',
+        sessionId: 'run_abc',
+        params: {node_name: '%fusion.1', module_name: 'main'},
+      });
+      expect(params.get(TOOL_URL_VERSION_PARAM)).toBe(
+        String(TOOL_URL_SCHEMA_VERSION),
+      );
+      expect(TOOL_URL_SCHEMA_VERSION).toBe(1);
+    });
+
+    it('sets tool, run, tool-specific params, and optional paths', () => {
+      const params = buildToolUrlSearchParams({
+        toolName: 'op_profile',
+        sessionId: 'session-1',
+        params: {host: 'worker0'},
+        sessionPath: '/tmp/sess',
+        runPath: '/tmp/run',
+      });
+      expect(params.get('tool')).toBe('op_profile');
+      expect(params.get('run')).toBe('session-1');
+      expect(params.get('host')).toBe('worker0');
+      expect(params.get('session_path')).toBe('/tmp/sess');
+      expect(params.get('run_path')).toBe('/tmp/run');
+    });
+
+    it('omits empty tool-specific param values', () => {
+      const params = buildToolUrlSearchParams({
+        toolName: 'trace_viewer',
+        sessionId: 'r1',
+        params: {keep: 'yes', drop: ''},
+      });
+      expect(params.get('keep')).toBe('yes');
+      expect(params.has('drop')).toBe(false);
+    });
+  });
+
+  describe('parseToolUrlSearchParams (compat)', () => {
+    it('treats missing v as schema version 1 (old bookmarks)', () => {
+      // Pre-versioned createToolUrl shape from #2899 (no `v` query param).
+      const oldUrl =
+        'tool=graph_viewer&run=run_old&module_name=main&node_name=%25fusion.1';
+      const parsed = parseToolUrlSearchParams(oldUrl);
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.toolName).toBe('graph_viewer');
+      expect(parsed.sessionId).toBe('run_old');
+      expect(parsed.params['module_name']).toBe('main');
+      expect(parsed.params['node_name']).toBe('%fusion.1');
+    });
+
+    it('parses explicit v=1 as schema version 1', () => {
+      const params = buildToolUrlSearchParams({
+        toolName: 'graph_viewer',
+        sessionId: 'run_new',
+        params: {module_name: 'main', node_name: '%add.2'},
+      });
+      const parsed = parseToolUrlSearchParams(params);
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.toolName).toBe('graph_viewer');
+      expect(parsed.sessionId).toBe('run_new');
+      expect(parsed.params['node_name']).toBe('%add.2');
+      // Version key is reserved, not a tool param.
+      expect(parsed.params[TOOL_URL_VERSION_PARAM]).toBeUndefined();
+    });
+
+    it('parses both old and new URLs to the same logical fields', () => {
+      const oldSearch =
+        'tool=trace_viewer&run=r1&session_path=%2Fsess&run_path=%2Frun';
+      const newSearch = buildToolUrlSearchParams({
+        toolName: 'trace_viewer',
+        sessionId: 'r1',
+        params: {},
+        sessionPath: '/sess',
+        runPath: '/run',
+      }).toString();
+
+      const oldParsed = parseToolUrlSearchParams(oldSearch);
+      const newParsed = parseToolUrlSearchParams(newSearch);
+
+      expect(oldParsed.schemaVersion).toBe(1);
+      expect(newParsed.schemaVersion).toBe(1);
+      expect(oldParsed.toolName).toBe(newParsed.toolName);
+      expect(oldParsed.sessionId).toBe(newParsed.sessionId);
+      expect(oldParsed.sessionPath).toBe(newParsed.sessionPath);
+      expect(oldParsed.runPath).toBe(newParsed.runPath);
+    });
+
+    it('accepts a leading ? on the query string', () => {
+      const parsed = parseToolUrlSearchParams('?tool=op_profile&run=r2');
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.toolName).toBe('op_profile');
+      expect(parsed.sessionId).toBe('r2');
+    });
+
+    it('surfaces a future explicit version number when present', () => {
+      const parsed = parseToolUrlSearchParams('v=2&tool=x&run=y');
+      expect(parsed.schemaVersion).toBe(2);
+      expect(parsed.toolName).toBe('x');
+      expect(parsed.sessionId).toBe('y');
+    });
+  });
+
+  describe('parseToolUrl (full href)', () => {
+    it('parses createToolUrl-style hrefs with hash fragment', () => {
+      const href =
+        'https://example.test/?v=1&tool=graph_viewer&run=sess1&module_name=m#profile';
+      const parsed = parseToolUrl(href);
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.toolName).toBe('graph_viewer');
+      expect(parsed.sessionId).toBe('sess1');
+      expect(parsed.params['module_name']).toBe('m');
+    });
+
+    it('parses old full hrefs without v as version 1', () => {
+      const href =
+        'https://example.test/?tool=graph_viewer&run=sess1&node_name=op#profile';
+      const parsed = parseToolUrl(href);
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.toolName).toBe('graph_viewer');
+      expect(parsed.params['node_name']).toBe('op');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `v=1` query param to `createToolUrl` deep links so the tool-link URL schema can evolve without breaking bookmarks.
- Export pure `buildToolUrlSearchParams` / `parseToolUrlSearchParams` helpers; parser treats **missing `v` as version 1** for pre-versioned URLs.
- Add Jasmine unit tests in `data_service_v2_test.ts` covering old vs new URLs (FIX-013 / follow-up to #2899).

## Test plan
- [x] Node smoke: new links emit `v=1`; missing `v` parses as schema version 1; old and new hrefs yield the same logical fields
- [x] Jasmine suite `data_service_v2_test.ts` listed on `//frontend/app/services/data_service_v2:tests` (internal harness)
- [ ] Confirm cross-tool links still open the intended tool/run with extra params