### PR TITLE
fix(category_filter): full-name title tooltips for truncated labels

### DIFF
--- a/frontend/app/components/controls/category_filter/BUILD
+++ b/frontend/app/components/controls/category_filter/BUILD
@@ -23,6 +23,18 @@ xprof_ng_module(
     ],
 )
 
+xprof_ng_module(
+    name = "tests",
+    testonly = True,
+    srcs = [
+        "category_filter_test.ts",
+    ],
+    deps = [
+        ":category_filter",
+        "//third_party/javascript/typings/jasmine",
+    ],
+)
+
 sass_binary(
     name = "category_filter_css",
     src = "category_filter.scss",

--- a/frontend/app/components/controls/category_filter/category_filter.ng.html
+++ b/frontend/app/components/controls/category_filter/category_filter.ng.html
@@ -1,6 +1,17 @@
 <mat-form-field class="control" *ngIf="columnLabel" appearance="outline">
   <mat-label>{{columnLabel}}</mat-label>
-  <mat-select (selectionChange)="updateFilter()" [(value)]="value">
-    <mat-option *ngFor="let option of options" [value]="option" [title]="option">{{option}}</mat-option>
+  <!--
+    The closed select trigger and option list are only ~120px wide, so long
+    category names (e.g. kernel names in perf counters) truncate. Expose the
+    full string via native title tooltips (FIX-037 / #2652).
+  -->
+  <mat-select
+    (selectionChange)="updateFilter()"
+    [(value)]="value"
+    [attr.title]="optionTitle(value)">
+    <mat-option
+      *ngFor="let option of options"
+      [value]="option"
+      [attr.title]="optionTitle(option)">{{option}}</mat-option>
   </mat-select>
 </mat-form-field>

--- a/frontend/app/components/controls/category_filter/category_filter.scss
+++ b/frontend/app/components/controls/category_filter/category_filter.scss
@@ -7,6 +7,16 @@
 }
 
 .control {
+  // Fixed width keeps filter rows compact in tools like perf counters; long
+  // names truncate and rely on [attr.title] for the full string (FIX-037).
   width: 120px;
   margin-right: 8px;
+
+  // Closed mat-select trigger: ellipsis so truncation is intentional, not
+  // mid-glyph clipping.
+  ::ng-deep .mat-mdc-select-value-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/frontend/app/components/controls/category_filter/category_filter.ts
+++ b/frontend/app/components/controls/category_filter/category_filter.ts
@@ -1,6 +1,18 @@
 import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ChangeDetectionStrategy} from '@angular/core';
 
 /**
+ * Full label string for category-filter title/tooltips when the UI truncates.
+ * Null/undefined map to empty so host title attributes stay well-formed.
+ */
+export function categoryFilterOptionTitle(
+    option: number|string|boolean|null|undefined): string {
+  if (option === null || option === undefined) {
+    return '';
+  }
+  return String(option);
+}
+
+/**
  * A category filter component.
  * The options are all unique values in the given column of dataTable.
  * Each cell in the column contains one value or multiple values if a
@@ -28,6 +40,11 @@ export class CategoryFilter implements OnChanges {
 
   @Output()
   changed = new EventEmitter<google.visualization.DataTableCellFilter>();
+
+  /** Full option text for native title tooltips on truncated labels. */
+  optionTitle(option: number|string|boolean|null|undefined): string {
+    return categoryFilterOptionTitle(option);
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     this.processData();

--- a/frontend/app/components/controls/category_filter/category_filter_test.ts
+++ b/frontend/app/components/controls/category_filter/category_filter_test.ts
@@ -1,0 +1,20 @@
+import {categoryFilterOptionTitle} from './category_filter';
+
+describe('categoryFilterOptionTitle', () => {
+  it('returns the full string for long category names', () => {
+    const longName =
+        'namespace::VeryLongKernelNameThatDoesNotFitInOneHundredTwentyPixels';
+    expect(categoryFilterOptionTitle(longName)).toBe(longName);
+  });
+
+  it('stringifies numbers and booleans used as filter values', () => {
+    expect(categoryFilterOptionTitle(42)).toBe('42');
+    expect(categoryFilterOptionTitle(true)).toBe('true');
+    expect(categoryFilterOptionTitle(false)).toBe('false');
+  });
+
+  it('maps null and undefined to empty title attributes', () => {
+    expect(categoryFilterOptionTitle(null)).toBe('');
+    expect(categoryFilterOptionTitle(undefined)).toBe('');
+  });
+});

--- a/frontend/app/components/graph_viewer/BUILD
+++ b/frontend/app/components/graph_viewer/BUILD
@@ -82,6 +82,9 @@ xprof_ng_module(
     ],
 )
 
+# Layout regression guards for graph viewer height / download button placement
+# (#2829 / FIX-016). Sources live in google3; keep this target wired so OSS
+# export does not drop the screenshot suite registration.
 xprof_ng_module(
     name = "screenshot_tests",
     testonly = True,

--- a/frontend/app/components/graph_viewer/graph_viewer.scss
+++ b/frontend/app/components/graph_viewer/graph_viewer.scss
@@ -26,6 +26,9 @@
 
 mat-sidenav {
   background: transparent;
+  // Do NOT set height: max-content here. That grows the sidenav with content,
+  // hides the container scrollbar, and breaks Op Profile / Graph Viewer
+  // scrolling (FIX-016 / #2833). Height comes from the flex host instead.
   // set fixed width to avoid weird behavior of mat-sidenav-content width change when collapsing the xprof sidenav.
   width: 350px;
   display: flex;


### PR DESCRIPTION
## Summary
- Expose full category filter labels via native `title` tooltips on both the **closed mat-select trigger** and each **mat-option**, so long names (e.g. kernel names in perf counters) remain readable when the 120px control truncates them (FIX-037 / #2652 follow-up).
- Add `categoryFilterOptionTitle` pure helper + Jasmine tests for long strings, numbers/booleans, and null/undefined.
- Document the graph viewer `mat-sidenav` ban on `height: max-content` (FIX-016 / #2833) and note the existing `#screenshot_tests` BUILD target from #2829.

## Test plan
- [x] Node smoke: `categoryFilterOptionTitle` matrix + template/CSS/BUILD wiring checks
- [x] Jasmine suite `category_filter_test.ts` (internal harness; listed on `:tests`)
- [ ] Manual: open perf counters / roofline with a long Kernel or Category value → hover closed select and option list shows full name
- [ ] Confirm graph viewer sidenav still scrolls (no `height: max-content` regression)