### PR TITLE
fix(pr-s): LiteTrace parity, event_stats defaults, util precision

### DIFF
--- a/frontend/app/components/trace_viewer_v2/timeline/constants.h
+++ b/frontend/app/components/trace_viewer_v2/timeline/constants.h
@@ -206,6 +206,8 @@ inline constexpr double kEventNavigationZoomFactor = 2.5;
 
 // UI Strings Constants
 // go/keep-sorted start
+// Two-decimal display for counter values (including utilization stats).
+// Full precision is preserved in the JSON model; format only for tooltips.
 inline constexpr char kCounterTooltipFormat[] = "Time: %s\nValue: %.2f";
 inline constexpr char kHideTrackTooltip[] = "Hide track";
 inline constexpr char kUnhideTrackTooltip[] = "Unhide track";

--- a/frontend/app/components/trace_viewer_v2/timeline/data_provider.cc
+++ b/frontend/app/components/trace_viewer_v2/timeline/data_provider.cc
@@ -577,8 +577,12 @@ void PopulateCounterTrack(
   }
 
   CounterData counter_data;
+  // Default empty when the track has no events or events omit event_stats
+  // (pre-#2860 traces). Downstream metrics JSON still emits a series string.
   if (!events.empty()) {
     counter_data.event_stats = events.front()->event_stats;
+  } else {
+    counter_data.event_stats.clear();
   }
   counter_data.timestamps.reserve(total_entries);
   counter_data.values.reserve(total_entries);

--- a/frontend/app/components/trace_viewer_v2/timeline/timeline.h
+++ b/frontend/app/components/trace_viewer_v2/timeline/timeline.h
@@ -62,6 +62,8 @@ struct CounterData {
   std::vector<double> values;
   double min_value = std::numeric_limits<double>::max();
   double max_value = std::numeric_limits<double>::lowest();
+  // Copied from CounterEvent::event_stats; empty when the field was absent on
+  // all source events (safe default for old traces).
   std::string event_stats;
 };
 

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h
@@ -77,6 +77,8 @@ struct TraceEvent {
 struct CounterEvent {
   ProcessId pid = 0;
   std::string name;
+  // Series id for counter values. Defaults to empty when the JSON field is
+  // absent (pre-event_stats traces / old producers) so consumers never crash.
   std::string event_stats;
   std::vector<Microseconds> timestamps;
   std::vector<double> values;

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser.cc
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser.cc
@@ -73,8 +73,12 @@ void ParseAndAppend(const emscripten::val& event, ParsedTraceEvents& result,
     if (event.hasOwnProperty("pid"))
       ev.pid = static_cast<ProcessId>(event["pid"].as<double>());
     if (event.hasOwnProperty("name")) ev.name = event["name"].as<std::string>();
-    if (event.hasOwnProperty("event_stats"))
+    // Default empty when absent so old traces without event_stats still parse.
+    if (event.hasOwnProperty("event_stats")) {
       ev.event_stats = event["event_stats"].as<std::string>();
+    } else {
+      ev.event_stats.clear();
+    }
 
     emscripten::val entries = event["entries"];
     // Avoid converting the entry to a vector or intermediate objects to

--- a/plugin/trace_viewer/tf_trace_viewer/tf-trace-viewer.html
+++ b/plugin/trace_viewer/tf_trace_viewer/tf-trace-viewer.html
@@ -2074,7 +2074,9 @@ dashboard would integrate trace viewer app using iframe.
       // A large counter event can generate a hash key that exceeds the maximum safe
       // value for a number, which throws a RangeError.
       const ungroupedCounterEvents = counterEvents.flatMap(event => {
-        const argName = event.event_stats;
+        // Default when event_stats is absent (old traces / producers before
+        // CounterEvent.event_stats). Avoids JS key "undefined" on args.
+        const argName = event.event_stats || 'value';
         return event.entries.map(entry => ({
             pid: event.pid,
             name: event.name,

--- a/xprof/convert/streaming_trace_viewer_processor_test.cc
+++ b/xprof/convert/streaming_trace_viewer_processor_test.cc
@@ -821,6 +821,11 @@ void CompareLevelDbTables(
   }
 }
 
+// Google3 differential suite: full TraceEventsContainer vs LiteTraceEvents on
+// real xplane fixtures (event counts by level + LevelDB table parity).
+// OSS-runnable synthetic parity is also covered by
+// XPlaneToTraceContainerTest.LiteVsFullEventCountParity.
+// FIX-021: dual lite/full paths must stay comparable; keep both suites green.
 class LiteTraceEventsParityTest : public ::testing::TestWithParam<std::string> {
 };
 

--- a/xprof/convert/trace_viewer/trace_events_to_json.h
+++ b/xprof/convert/trace_viewer/trace_events_to_json.h
@@ -482,10 +482,10 @@ class JsonEventWriter {
       case TraceEventArguments::Argument::kUintValue:
         return absl::StrCat(arg.uint_value());
       case TraceEventArguments::Argument::kDoubleValue:
-        // Displaying two decimal places for Perf Counter utilizations.
-        if (IsUtilizationBasedStats(arg.name())) {
-          return absl::StrFormat("%.2f", arg.double_value());
-        }
+        // Keep full precision in the JSON model. Display-side formatting for
+        // utilization stats (e.g. two decimals) lives in the UI
+        // (kCounterTooltipFormat / catapult). IsUtilizationBasedStats()
+        // identifies those series for consumers that need UI-side formatting.
         return absl::StrFormat("%.17g", arg.double_value());
       case TraceEventArguments::Argument::kRefValue: {
         const auto& it = trace_.name_table().find(arg.ref_value());
@@ -604,11 +604,9 @@ class JsonEventWriter {
     if (std::isfinite(value)) {
       output_->Append(JsonEscape(name));
       // "%.17g" is the default double format in google::protobuf::util::JsonFormat.
-      if (IsUtilizationBasedStats(name)) {
-        absl::Format(output_, ":%.2f", value);
-      } else {
-        absl::Format(output_, ":%.17g", value);
-      }
+      // Do not pre-round utilization stats here; keep full precision for
+      // parsers. UI shows two decimals when needed (see IsUtilizationBasedStats).
+      absl::Format(output_, ":%.17g", value);
     } else if (std::isinf(value)) {
       output_->Append(JsonEscape(name), R"(:"Infinity")");
     } else if (std::isinf(-value)) {

--- a/xprof/convert/trace_viewer/trace_events_to_json_test.cc
+++ b/xprof/convert/trace_viewer/trace_events_to_json_test.cc
@@ -21,12 +21,13 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "testing/base/public/gmock.h"
-#include "<gtest/gtest.h>"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_format.h"
 #include "google/protobuf/map.h"
 #include "xprof/convert/trace_viewer/trace_viewer_color.h"
 #include "plugin/xprof/protobuf/task.pb.h"
@@ -322,6 +323,58 @@ TYPED_TEST(JsonEventWriterTypedTest, CounterEventTest) {
   EXPECT_EQ(
       output_str,
       R"({"pid":1,"name":"counter_event","ph":"C","event_stats":"arg1","entries":[[1,100]]})");
+}
+
+// Utilization stats stay full-precision numbers in JSON (not pre-rounded to
+// two decimals). Display formatting is UI-side.
+TYPED_TEST(JsonEventWriterTypedTest, UtilizationCounterKeepsFullPrecision) {
+  Trace trace;
+  DefaultTraceEventsColorer colorer;
+  absl::btree_map<uint64_t, uint64_t> references;
+  std::string output_str;
+  TypeParam output(&output_str);
+  JsonEventWriter<TypeParam, RawData> writer(&colorer, trace, references,
+                                             &output);
+
+  TraceEvent event;
+  event.set_device_id(1);
+  event.set_name("MXU");
+  event.set_timestamp_ps(1000000);
+  RawData raw_data;
+  TraceEventArguments::Argument& arg = *raw_data.mutable_args()->add_arg();
+  arg.set_name("MXU (util %)");
+  // Value with more than 2 significant fractional digits.
+  constexpr double kUtil = 12.3456789;
+  arg.set_double_value(kUtil);
+  event.set_raw_data(raw_data.SerializeAsString());
+  writer.AddCounterEvent(event);
+
+  output_str += "]}";
+
+  EXPECT_THAT(output_str, HasSubstr("\"event_stats\":\"MXU (util %)\""));
+  // Full precision (%.17g), not the former "%.2f" truncation to 12.35.
+  EXPECT_THAT(output_str, HasSubstr(absl::StrFormat("%.17g", kUtil)));
+  EXPECT_THAT(output_str, Not(HasSubstr(",12.35]")));
+}
+
+// Counters with no args omit event_stats; consumers must default the field.
+TYPED_TEST(JsonEventWriterTypedTest, CounterEventOmitsEventStatsWhenNoArgs) {
+  Trace trace;
+  DefaultTraceEventsColorer colorer;
+  absl::btree_map<uint64_t, uint64_t> references;
+  std::string output_str;
+  TypeParam output(&output_str);
+  JsonEventWriter<TypeParam, RawData> writer(&colorer, trace, references,
+                                             &output);
+
+  TraceEvent event;
+  event.set_device_id(1);
+  event.set_name("empty_counter");
+  event.set_timestamp_ps(1000000);
+  writer.AddCounterEvent(event);
+
+  EXPECT_THAT(output_str, HasSubstr(R"("ph":"C")"));
+  EXPECT_THAT(output_str, Not(HasSubstr("event_stats")));
 }
 
 TYPED_TEST(JsonEventWriterTypedTest, AsyncEventTest) {

--- a/xprof/convert/trace_viewer/trace_events_util.h
+++ b/xprof/convert/trace_viewer/trace_events_util.h
@@ -38,6 +38,9 @@ inline absl::string_view ResourceName(const Trace& trace, uint32_t device_id,
 }
 
 // Returns true if the stat name indicates it is a utilization-based metric.
+// Used by display-side formatters (two-decimal util % in the UI). The JSON
+// export path keeps full double precision for these stats so parsers are not
+// forced through a string-rounded data path.
 inline bool IsUtilizationBasedStats(absl::string_view name) {
   return absl::EndsWith(name, "(util %)");
 }

--- a/xprof/convert/trace_viewer/trace_events_util_test.cc
+++ b/xprof/convert/trace_viewer/trace_events_util_test.cc
@@ -1,8 +1,9 @@
 #include "xprof/convert/trace_viewer/trace_events_util.h"
+
 #include <cstdint>
 #include <limits>
 
-#include "<gtest/gtest.h>"
+#include "gtest/gtest.h"
 #include "xla/tsl/profiler/utils/timespan.h"
 
 namespace tensorflow {
@@ -58,6 +59,14 @@ TEST(ExpandTraceSpanTest, BadTimestampsAreIgnored) {
       &trace);
   EXPECT_EQ(trace.min_timestamp_ps(), 5);
   EXPECT_EQ(trace.max_timestamp_ps(), 20);
+}
+
+TEST(IsUtilizationBasedStatsTest, MatchesUtilPercentSuffix) {
+  EXPECT_TRUE(IsUtilizationBasedStats("MXU (util %)"));
+  EXPECT_TRUE(IsUtilizationBasedStats("HBM BW (util %)"));
+  EXPECT_FALSE(IsUtilizationBasedStats("power"));
+  EXPECT_FALSE(IsUtilizationBasedStats("util"));
+  EXPECT_FALSE(IsUtilizationBasedStats(""));
 }
 
 }  // namespace

--- a/xprof/convert/xplane_to_trace_container_test.cc
+++ b/xprof/convert/xplane_to_trace_container_test.cc
@@ -15,9 +15,10 @@ limitations under the License.
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
-#include "testing/base/public/gmock.h"
-#include "<gtest/gtest.h>"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/strings/match.h"
@@ -27,6 +28,7 @@ limitations under the License.
 #include "xla/tsl/profiler/utils/trace_utils.h"
 #include "xla/tsl/profiler/utils/xplane_schema.h"
 #include "xprof/convert/file_utils.h"
+#include "xprof/convert/trace_viewer/lite_trace_events.h"
 #include "xprof/convert/xplane_to_trace_container.h"
 #include "xprof/utils/tensorflow_utils.h"
 
@@ -204,6 +206,72 @@ TEST(XPlaneToTraceContainerTest, SubprocessHostTrace_ConvertsToTraceEvents) {
   });
   EXPECT_TRUE(event1_found);
   EXPECT_TRUE(event2_found);
+}
+
+// Differential coverage: full TraceEventsContainer vs LiteTraceEvents on the
+// same synthetic XSpace. Catches dual-path drift for event counts and
+// visibility levels without google3-only LevelDB fixtures.
+// Deeper LevelDB table parity lives in streaming_trace_viewer_processor_test
+// (LiteTraceEventsParityTest; google3 data deps).
+TEST(XPlaneToTraceContainerTest, LiteVsFullEventCountParity) {
+  XSpace xspace;
+  CHECK_OK(ParseTextFormatFromString(
+      absl::Substitute(
+          "planes {"
+          "  name: \"/device:GPU:0\""
+          "  lines {"
+          "    name: \"_counters_\""
+          "    events {"
+          "      metadata_id: 100"
+          "      offset_ps: $0"
+          "      stats { metadata_id: 200 uint64_value: 100 }"
+          "    }"
+          "    events {"
+          "      metadata_id: 100"
+          "      offset_ps: $1"
+          "      stats { metadata_id: 200 uint64_value: 200 }"
+          "    }"
+          "  }"
+          "  lines {"
+          "    id: 14"
+          "    name: \"Stream #14(MemcpyH2D)\""
+          "    timestamp_ns: $2"
+          "    events {"
+          "      metadata_id: 10"
+          "      offset_ps: 0"
+          "      duration_ps: $1"
+          "    }"
+          "    events {"
+          "      metadata_id: 10"
+          "      offset_ps: $0"
+          "      duration_ps: $3"
+          "    }"
+          "  }"
+          "  event_metadata {key: 10 value: { id: 10 name: \"MemcpyD2D\" }}"
+          "  event_metadata {key: 100 value: { id: 100 name: \"Counter 1\" }}"
+          "  stat_metadata {key: 200 value: { id: 200 name: \"counter_1\"}}"
+          "}",
+          tsl::profiler::UniToPico(1), tsl::profiler::UniToPico(2),
+          tsl::profiler::UniToNano(1), tsl::profiler::UniToNano(500)),
+      &xspace));
+
+  TraceEventsContainer full_container;
+  ConvertXSpaceToTraceEventsContainer("localhost", xspace, &full_container);
+
+  TraceEventLiteContainer lite_container;
+  ConvertXSpaceToLiteTraceEventsContainer("localhost", xspace, &lite_container);
+
+  EXPECT_EQ(full_container.NumEvents(), NumEvents(lite_container));
+  EXPECT_GT(full_container.NumEvents(), 0);
+
+  auto full_by_level = full_container.GetTraceEventsByLevel();
+  auto lite_by_level = LiteTraceEventsByLevel(&lite_container);
+  EXPECT_EQ(full_by_level.size(), lite_by_level.size());
+  for (size_t i = 0; i < full_by_level.size() && i < lite_by_level.size();
+       ++i) {
+    EXPECT_EQ(full_by_level[i].size(), lite_by_level[i].size())
+        << "Mismatch at visibility level " << i;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Critique follow-up for LiteTrace dual-path risk, CounterEvent `event_stats` schema expansion, and perf-counter utilization JSON precision (FIX-021, FIX-030, FIX-032).

- **FIX-021:** OSS synthetic differential test comparing full `TraceEventsContainer` vs `LiteTraceEvents` event counts and visibility levels on the same XSpace; documents existing google3 LevelDB parity suite (`LiteTraceEventsParityTest`).
- **FIX-030:** Default `event_stats` when absent so pre-#2860 traces do not crash (TV1 uses `'value'`; TV2 keeps empty string defaults + comments).
- **FIX-032:** Stop pre-rounding utilization doubles to `%.2f` in the JSON data path; emit full `%.17g` precision. UI already formats counter tooltips to two decimals (`kCounterTooltipFormat`).

## Test plan
- [x] `bazel test //xprof/convert:xplane_to_trace_container_test`
- [x] `bazel test //xprof/convert/trace_viewer:trace_events_util_test`
- [x] `bazel test //xprof/convert/trace_viewer:trace_events_to_json_test` (new utilization precision + omit-event_stats cases; pre-existing `JsonEscapeTest` unicode failure filtered)

## Related
- #2852 LiteTraceEvents
- #2860 event_stats on CounterEvent
- #2818 two-decimal perf counter utilization