### PR TITLE
test(trace_viewer_v2): interaction matrix + bookmark schema version

### DIFF
--- a/frontend/app/components/trace_viewer_v2/timeline/constants.h
+++ b/frontend/app/components/trace_viewer_v2/timeline/constants.h
@@ -132,6 +132,15 @@ inline constexpr ImU32 kBookmarkColor = kPink80;
 inline constexpr Pixel kBookmarkLabelPadding = 4.0f;
 inline constexpr Pixel kBookmarkThickness = 2.0f;
 // go/keep-sorted end
+//
+// Bookmark storage schema version.
+// Version 1: ordered list of timestamps in microseconds only (session-local).
+// Bump when the serialized / persisted representation gains fields (labels,
+// event ids, ranges, etc.). External storage that omits a version field must
+// be treated as version 1 for forward compatibility.
+// See also kEventIdAlgorithmVersion — EventId churn does not invalidate v1
+// bookmarks because they key on time, not event identity.
+inline constexpr int kBookmarkSchemaVersion = 1;
 
 // Close Button Constants
 // go/keep-sorted start

--- a/frontend/app/components/trace_viewer_v2/timeline/timeline.h
+++ b/frontend/app/components/trace_viewer_v2/timeline/timeline.h
@@ -32,6 +32,40 @@ static constexpr int kAll = -1;
 static constexpr int kNone = -2;
 }  // namespace FlowCategoryFilter
 
+// Pointer / keyboard interaction mode for the timeline track area.
+//
+// Mode state machine (primary gesture on left-drag; modifiers override):
+//
+//   kSelect (1)  — drag: rectangle-select events/counters
+//   kPan    (2)  — drag: pan X / scroll Y  (default)
+//   kZoom   (3)  — drag vertically: zoom about pivot
+//   kTiming (4)  — drag: create/edit selected time ranges (curtains)
+//
+// Cross-cutting modifiers and features (apply regardless of mode unless
+// noted; order on mouse-down / release matters for conflict resolution):
+//
+//   Shift+drag (non-kSelect)  → temporary timing selection (time range)
+//   Ctrl/Meta+click           → add bookmark at click time (feature:
+//                               bookmarks). Handled on mouse-up and
+//                               bypasses tiny time-range creation so a
+//                               slight move during the click does not
+//                               create a curtain.
+//   Edge hover on a curtain   → resize that selected time range (takes
+//                               priority over starting a new drag mode
+//                               action). Resize applies snap when enabled.
+//   Snap-to-time-range        → when enabled, timing selections and
+//                               curtain resizes snap edges to nearby
+//                               event edges / other curtains. Snap uses
+//                               only visible (non-hidden, non-collapsed
+//                               flame) tracks. Inactive in kSelect /
+//                               plain pan without Shift.
+//   Hide process track        → removes the process (and children) from
+//                               layout when track management is enabled;
+//                               hidden tracks are skipped for snap edge
+//                               discovery.
+//
+// Keyboard: 1/2/3/4 switch modes (see HandleKeyboard). Esc cancels an
+// in-progress selection or resize.
 enum class MouseMode {
   // Select events in an area (legacy mode 1)
   kSelect = 1,
@@ -284,12 +318,20 @@ class Timeline {
   void set_bookmarks_enabled(bool enabled) { bookmarks_enabled_ = enabled; }
   bool bookmarks_enabled() const { return bookmarks_enabled_; }
 
+  // Schema version for bookmark storage (see kBookmarkSchemaVersion).
+  // Persist this alongside bookmarks() when serializing so future schema
+  // changes can migrate; missing version in external storage means v1.
+  static constexpr int GetBookmarkSchemaVersion() {
+    return kBookmarkSchemaVersion;
+  }
+
   // Adds a bookmark at the specified time if one doesn't already exist nearby.
   void AddBookmark(Microseconds time);
 
   // Removes the specified bookmark.
   void RemoveBookmark(Microseconds time);
 
+  // Session-local bookmark timestamps in microseconds (schema v1 payload).
   const std::vector<Microseconds>& bookmarks() const { return bookmarks_; }
   void set_track_management_enabled(bool enabled) {
     track_management_enabled_ = enabled;

--- a/frontend/app/components/trace_viewer_v2/timeline/timeline_test.cc
+++ b/frontend/app/components/trace_viewer_v2/timeline/timeline_test.cc
@@ -7971,6 +7971,213 @@ TEST_F(TimelineTimeRangeResizeTest, ResizeWithSnapping) {
   EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[1].end(), 100.0);
 }
 
+// =============================================================================
+// FIX-014 / FIX-024: TV2 interaction matrix (snap × resize × bookmarks × hide)
+// + bookmark schema version.
+//
+// Features landed close together (#2801 snap, #2846 resize, #2845 bookmarks,
+// #2855 hide). These tests pin critical cross-feature pairs and pointer-mode
+// conflict resolution documented on MouseMode in timeline.h.
+// =============================================================================
+
+TEST(TimelineTest, BookmarkSchemaVersionIsV1) {
+  // Session-local bookmarks store timestamps only (schema v1). Callers that
+  // persist bookmarks must include this version; missing version ≡ v1.
+  EXPECT_EQ(Timeline::GetBookmarkSchemaVersion(), kBookmarkSchemaVersion);
+  EXPECT_EQ(kBookmarkSchemaVersion, 1);
+  // EventId algorithm is independently versioned; v1 bookmarks key on time.
+  EXPECT_EQ(kEventIdAlgorithmVersion, 1);
+}
+
+TEST(TimelineTest, BookmarkSchemaVersionIndependentOfBookmarkContents) {
+  ColorPalette palette = ColorPalette::Default();
+  Timeline timeline(palette);
+  timeline.set_bookmarks_enabled(true);
+  EXPECT_EQ(timeline.GetBookmarkSchemaVersion(), 1);
+  timeline.AddBookmark(42.0);
+  timeline.AddBookmark(100.0);
+  EXPECT_EQ(timeline.GetBookmarkSchemaVersion(), 1);
+  EXPECT_THAT(timeline.bookmarks(), ElementsAre(42.0, 100.0));
+}
+
+// Snap must ignore event edges on hidden process tracks (group_visible_=false).
+TEST_F(TimelineDragSelectionTest, SnapIgnoresEventsOnHiddenTracks) {
+  timeline_.set_snap_to_time_range_enabled(true);
+  timeline_.set_track_management_enabled(true);
+
+  FlameChartTimelineData data;
+  // Event on Process A from 100–200 us — would be a snap target if visible.
+  data.entry_levels = {0};
+  data.entry_total_times = {100.0};
+  data.entry_self_times = {100.0};
+  data.entry_start_times = {100.0};
+  data.entry_names = {"hidden_event"};
+  data.entry_event_ids = {1};
+  data.entry_pids = {1};
+  data.entry_tids = {1};
+  data.entry_args = {{}};
+  data.groups = {{Group::Type::kFlame, "Process A", "", 0, 0, true}};
+  data.events_by_level = {{0}};
+  timeline_.SetTimelineData(data);
+  timeline_.HideTrack("Process A");
+
+  SimulateFrame();
+  ASSERT_FALSE(timeline_.group_visible().empty());
+  EXPECT_FALSE(timeline_.group_visible()[0]);
+
+  ImGuiIO& io = ImGui::GetIO();
+  // Drag near the hidden event edges (99→201 us). Without hide this snaps to
+  // 100–200; with hide, raw pixel times must be kept.
+  io.MousePos = ImVec2(GetTimelineStartX() + 990.0f, kEmptyAreaY);
+  io.AddMouseButtonEvent(0, true);
+  SimulateFrame();
+  io.MousePos = ImVec2(GetTimelineStartX() + 2010.0f, kEmptyAreaY);
+  SimulateFrame();
+  io.AddMouseButtonEvent(0, false);
+  SimulateFrame();
+
+  ASSERT_EQ(timeline_.selected_time_ranges().size(), 1);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].start(), 99.0);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].end(), 201.0);
+}
+
+// Bookmarks are independent of hide/snap: adding a bookmark does not create a
+// time range, and hide does not clear existing bookmarks.
+TEST_F(TimelineDragSelectionTest, BookmarksSurviveHideAndDoNotCreateTimeRange) {
+  timeline_.set_bookmarks_enabled(true);
+  timeline_.set_track_management_enabled(true);
+  timeline_.set_snap_to_time_range_enabled(true);
+
+  FlameChartTimelineData data;
+  data.entry_levels = {0};
+  data.entry_total_times = {50.0};
+  data.entry_self_times = {50.0};
+  data.entry_start_times = {10.0};
+  data.entry_names = {"ev"};
+  data.entry_event_ids = {1};
+  data.entry_pids = {1};
+  data.entry_tids = {1};
+  data.entry_args = {{}};
+  data.groups = {{Group::Type::kFlame, "Process A", "", 0, 0, true}};
+  data.events_by_level = {{0}};
+  timeline_.SetTimelineData(data);
+
+  timeline_.AddBookmark(25.0);
+  EXPECT_THAT(timeline_.bookmarks(), ElementsAre(25.0));
+
+  timeline_.HideTrack("Process A");
+  EXPECT_THAT(timeline_.bookmarks(), ElementsAre(25.0));
+  EXPECT_TRUE(timeline_.selected_time_ranges().empty());
+  EXPECT_EQ(timeline_.GetBookmarkSchemaVersion(), 1);
+}
+
+// Resize drag (with or without Ctrl) must not add a bookmark — only pure
+// Ctrl/Meta+click does. Prevents resize×bookmark gesture conflict.
+TEST_F(TimelineTimeRangeResizeTest, ResizeDragDoesNotAddBookmarkEvenWithCtrl) {
+  timeline_.set_bookmarks_enabled(true);
+  AddSelectedTimeRange(50.0, 100.0);
+
+  ImGuiIO& io = ImGui::GetIO();
+  const float origin_x = GetTimelineStartX();
+  constexpr double kPxPerTime = 10.0;
+
+  // Start on end edge and drag with Ctrl held (would bookmark if a click).
+  io.AddKeyEvent(ImGuiMod_Ctrl, true);
+  io.AddMousePosEvent(origin_x + 100.0 * kPxPerTime, 50.0f);
+  io.AddMouseButtonEvent(0, true);
+  SimulateFrame();
+  io.AddMousePosEvent(origin_x + 150.0 * kPxPerTime, 50.0f);
+  SimulateFrame();
+  io.AddMouseButtonEvent(0, false);
+  SimulateFrame();
+  io.AddKeyEvent(ImGuiMod_Ctrl, false);
+
+  ASSERT_EQ(timeline_.selected_time_ranges().size(), 1);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].start(), 50.0);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].end(), 150.0);
+  EXPECT_TRUE(timeline_.bookmarks().empty());
+}
+
+// Ctrl+click on a curtain edge adds a bookmark and does not mutate the range
+// (click distance under threshold → is_click; bookmark bypasses selection).
+TEST_F(TimelineTimeRangeResizeTest, CtrlClickOnRangeEdgeAddsBookmarkNotResize) {
+  timeline_.set_bookmarks_enabled(true);
+  AddSelectedTimeRange(50.0, 100.0);
+
+  ImGuiIO& io = ImGui::GetIO();
+  const float origin_x = GetTimelineStartX();
+  constexpr double kPxPerTime = 10.0;
+
+  io.AddMousePosEvent(origin_x + 100.0 * kPxPerTime, 50.0f);
+  io.AddMouseButtonEvent(0, true);
+  SimulateFrame();
+  io.AddKeyEvent(ImGuiMod_Ctrl, true);
+  io.AddMouseButtonEvent(0, false);
+  SimulateFrame();
+  io.AddKeyEvent(ImGuiMod_Ctrl, false);
+
+  ASSERT_EQ(timeline_.selected_time_ranges().size(), 1);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].start(), 50.0);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[0].end(), 100.0);
+  EXPECT_FALSE(timeline_.bookmarks().empty());
+}
+
+// Parameterized: Ctrl+click adds a bookmark in every pointer mode without
+// creating a timing curtain (mode conflict matrix).
+class BookmarkAcrossMouseModesTest
+    : public TimelineDragSelectionTest,
+      public ::testing::WithParamInterface<MouseMode> {};
+
+TEST_P(BookmarkAcrossMouseModesTest, CtrlClickAddsBookmarkWithoutTimeRange) {
+  // Shift is on in TimelineDragSelectionTest SetUp; clear so only Ctrl matters.
+  ImGui::GetIO().AddKeyEvent(ImGuiMod_Shift, false);
+  SimulateFrame();
+
+  timeline_.set_bookmarks_enabled(true);
+  timeline_.set_mouse_mode(GetParam());
+  EXPECT_EQ(timeline_.mouse_mode(), GetParam());
+
+  ImGuiIO& io = ImGui::GetIO();
+  const float click_x = GetTimelineStartX() + 100.0f;
+  io.MousePos = ImVec2(click_x, kEmptyAreaY);
+  io.AddMouseButtonEvent(0, true);
+  SimulateFrame();
+  io.AddKeyEvent(ImGuiMod_Ctrl, true);
+  io.AddMouseButtonEvent(0, false);
+  SimulateFrame();
+  io.AddKeyEvent(ImGuiMod_Ctrl, false);
+
+  EXPECT_FALSE(timeline_.bookmarks().empty());
+  EXPECT_TRUE(timeline_.selected_time_ranges().empty());
+  // Mode must be unchanged by bookmark gesture.
+  EXPECT_EQ(timeline_.mouse_mode(), GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(AllPointerModes, BookmarkAcrossMouseModesTest,
+                         ::testing::Values(MouseMode::kSelect, MouseMode::kPan,
+                                           MouseMode::kZoom,
+                                           MouseMode::kTiming));
+
+// Snap during resize still applies when the snap target is another curtain,
+// independent of bookmark feature flag (resize × snap matrix pair).
+TEST_F(TimelineTimeRangeResizeTest, ResizeSnapsToCurtainWithBookmarksEnabled) {
+  timeline_.set_mouse_mode(MouseMode::kTiming);
+  timeline_.set_snap_to_time_range_enabled(true);
+  timeline_.set_bookmarks_enabled(true);
+  timeline_.AddBookmark(75.0);  // bookmarks are not snap targets
+
+  AddSelectedTimeRange(100.0, 150.0);  // snap target curtain
+  AddSelectedTimeRange(10.0, 50.0);    // range under resize
+
+  // Threshold = 16/10 = 1.6us; drag end 50 → 99 should snap to 100, not 75.
+  Drag(50.0, 99.0, /*shift=*/true);
+
+  ASSERT_EQ(timeline_.selected_time_ranges().size(), 2);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[1].start(), 10.0);
+  EXPECT_DOUBLE_EQ(timeline_.selected_time_ranges()[1].end(), 100.0);
+  EXPECT_THAT(timeline_.bookmarks(), ElementsAre(75.0));
+}
+
 TEST_F(MockTimelineImGuiFixture, TriggersZoomWhenNavigatedEventNotPresent) {
   timeline_.SetTimelineData(
       CreateTimelineData({{"root", 0.0, 10000000.0, 0, 1, 1, 0}}));

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event.h
@@ -21,6 +21,15 @@ using ThreadId = uint64_t;
 // EventId is a unique identifier for an event.
 // Event timestamp, duration and its name are used to generate the event ID.
 // See http://shortn/_lVpPbx16ZS for more details.
+//
+// Algorithm version (kEventIdAlgorithmVersion):
+//   v1 — Fingerprint64 of "name:ts_ps:dur_ps" where ts/dur are rounded to
+//        picoseconds (see GenerateEventId). Stable across sub-us float noise.
+// Changing the algorithm invalidates consumers that key on EventId (search
+// navigation, deep links). Bump kEventIdAlgorithmVersion when the formula
+// changes. Session-local bookmarks (kBookmarkSchemaVersion) store timestamps
+// only and are unaffected by EventId algorithm churn.
+inline constexpr int kEventIdAlgorithmVersion = 1;
 using EventId = uint64_t;
 // Timestamps are in microseconds, as specified in go/trace-event-format.
 // An example ts: 6845940.1418570001

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser_core.h
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser_core.h
@@ -19,6 +19,12 @@ GetPrettyNames();
 
 // Generates a stable event ID robust against sub-microsecond floating-point
 // representation differences (e.g. string round-tripping vs integer division).
+//
+// Algorithm version: kEventIdAlgorithmVersion (currently 1).
+// Formula (v1): Fingerprint64(StrCat(name, ":", round(ts*1e6), ":",
+// round(dur*1e6))) with ts/dur converted to integer picoseconds.
+// Do not change the formula without bumping kEventIdAlgorithmVersion and
+// updating consumers that persist EventId values.
 EventId GenerateEventId(absl::string_view name, Microseconds ts,
                         Microseconds dur);
 

--- a/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser_core_test.cc
+++ b/frontend/app/components/trace_viewer_v2/trace_helper/trace_event_parser_core_test.cc
@@ -203,6 +203,12 @@ TEST(TraceEventParserCoreTest, ProcessAsyncEventsBeginEndPair) {
             GenerateEventId("dma_transfer", 1.0, 4.0));
 }
 
+TEST(TraceEventParserCoreTest, EventIdAlgorithmVersionIsV1) {
+  // Documented algorithm version for GenerateEventId. Bump when the formula
+  // changes so consumers that persist EventIds can detect incompatibility.
+  EXPECT_EQ(kEventIdAlgorithmVersion, 1);
+}
+
 TEST(TraceEventParserCoreTest, GenerateEventIdTest) {
   // Stable hashing: Identical inputs produce the same ID
   EventId id1 = GenerateEventId("event_a", 10.123456, 5.654321);


### PR DESCRIPTION
## Summary
Closes critique follow-ups **FIX-014** (TV2 interaction matrix: snap × resize × bookmarks × hide) and **FIX-024** (event ID stability + bookmark schema version).

Features #2801 / #2846 / #2845 / #2855 landed close together with limited cross tests. This PR:

- Documents the `MouseMode` pointer state machine and conflict resolution (bookmark vs curtain vs resize vs snap vs hide) on `timeline.h`
- Adds critical matrix coverage in `timeline_test.cc` (hide×snap, bookmark×resize, Ctrl+click across all modes, resize×snap with bookmarks enabled)
- Introduces `kBookmarkSchemaVersion = 1` (timestamps-only payload) exposed via `Timeline::GetBookmarkSchemaVersion()`
- Documents `kEventIdAlgorithmVersion = 1` for `GenerateEventId` (Fingerprint64 of `name:ts_ps:dur_ps`) so consumers can detect formula changes

## Test plan
- [x] `//frontend/app/components/trace_viewer_v2/trace_helper:trace_event_parser_core_test` (includes `EventIdAlgorithmVersionIsV1`) — PASSED
- [x] Source smoke: schema constants + all new matrix case names present
- [ ] `//frontend/app/components/trace_viewer_v2/timeline:timeline_test` (google3 ImGui / gtest harness; new cases under FIX-014 section)

## Notes
- v1 bookmarks key on **time**, not EventId, so EventId algorithm churn does not invalidate bookmarks
- Missing external schema version must be treated as v1 (migration note in `constants.h`)