### PR TITLE
fix(pr-u): Labs a11y checklist and icon-control aria-labels

### DIFF
--- a/frontend/app/components/labs/a11y_checklist.md
+++ b/frontend/app/components/labs/a11y_checklist.md
@@ -1,0 +1,80 @@
+# XProf Labs accessibility (a11y) checklist
+
+**Scope:** Material 3 Labs marketplace + playground (`frontend/app/components/labs/`)
+and curated lab tools under `labs/` (e.g. Memory Analysis).
+
+**Source:** FIX-041 / critique of Labs UI landings (#2892 and follow-ups).
+
+**Status:** Partial pass — critical icon-control labels addressed; remaining items
+tracked as debt below. Labs remains behind the experimental `labs` feature flag;
+do not expand surface area without updating this checklist.
+
+## How to re-run a smoke pass
+
+1. Enable Labs in the profiler UI (experimental flag / tool entry that loads
+   `xprof-labs`).
+2. Keyboard: Tab through header → tabs → filter chips → search → view toggle →
+   cards → Launch / more / favorite.
+3. Screen reader (optional): VoiceOver / NVDA on the same path; confirm name,
+   role, and state for toggles and icon-only buttons.
+4. Curated tool: open Memory Analysis and Tab through sidebar toggle, hierarchy /
+   metric / color toggles, tabs, search, table, zoom controls.
+
+## Checklist
+
+| Area | Criterion | Status | Notes |
+|------|-----------|--------|-------|
+| Feature flag | Labs stays experimental; no a11y-only unblock of flag | **OK** | `isLabsEnabled()` gate unchanged |
+| Page structure | One `h1` ("XProf Labs"); sections use headings | **OK** | Header `h1` present |
+| Search field | Accessible name on marketplace search | **OK** | `aria-label="Search experiments"` |
+| Playground code | Textarea named | **OK** | `aria-label="Python trace visualization code"` |
+| Playground AI prompt | Input named | **OK** | `aria-label="AI prompt for generating visualization code"` |
+| Filter chips | Clear name + pressed state | **Fixed** | Text label + `aria-pressed` |
+| Icon-only controls | Every icon button has `aria-label` (not `title` alone) | **Fixed** | Discard, clear search, grid/list, favorite, more options |
+| Text buttons | Visible text is sufficient name | **OK** | Back, Start experiment, Launch, Run, Ask AI, tabs |
+| Keyboard — tabs | Curated / My Experiments operable with keyboard | **Partial** | Native `<button>` receives focus; not `role="tablist"` yet |
+| Keyboard — chips | Category filters focusable and activatable | **OK** | Native `<button>`; Enter/Space activate |
+| Keyboard — cards | Launch reachable; favorite / more do not trap focus | **OK** | Buttons in tab order |
+| Focus visible | `:focus-visible` / Material focus rings usable | **Debt** | Rely on browser/Material defaults; custom SCSS may dull rings |
+| Live regions | Search result count / AI generating announced | **Debt** | Result header is visual only; spinner not `aria-live` |
+| Color contrast | Body text and chip active states meet WCAG AA | **Debt** | Not audited in this pass; Material 3 tokens assumed |
+| SVG visuals (Memory Analysis) | Flame/treemap not sole channel for data | **Debt** | Table provides parallel data; charts are mouse-heavy |
+| Memory Analysis toggles | Hierarchy / size / color groups labeled | **OK** | Existing `aria-label` on `mat-button-toggle-group` |
+| Memory Analysis icon buttons | Sidebar + zoom controls labeled | **Fixed** | `aria-label` on icon buttons |
+| Loading indicators | Progress / spinner named | **Partial** | Memory Analysis spinner labeled; marketplace has no top-level bar |
+| Disabled actions | Disabled review/draft convey why when focused | **Debt** | `[disabled]="true"` only; no `aria-describedby` |
+
+## Critical gaps fixed in this pass
+
+- Icon-only Labs marketplace / playground controls: `aria-label` added (previously
+  `title` only, which is weak for AT).
+- Filter chips: `aria-pressed` bound to selection so toggle state is exposed.
+- Memory Analysis: sidebar toggle, flame-graph and treemap zoom/reset icon
+  buttons, and loading spinner named for AT.
+
+## Remaining debt (file or follow up)
+
+1. **Tab pattern:** Promote `.labs-tabs` to a proper tabs widget
+   (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`, arrow-key
+   navigation) instead of two independent buttons.
+2. **Focus management:** Moving experiments ↔ playground should move focus to the
+   new view heading (or first control) so keyboard users are not left on a
+   removed control.
+3. **Playground chart:** Decorative bar mock should be `aria-hidden` or replaced
+   with a real chart that exposes data via text/table.
+4. **Contrast audit:** Run axe / Lighthouse on Labs + Memory Analysis with light
+   (and dark, if applicable) themes; fix chip and muted text ratios.
+5. **SVG interaction:** Flame graph / treemap nodes are clickable `<g>` without
+   keyboard equivalents; consider focusable nodes or rely on the buffers table
+   as the accessible path and document that contract.
+6. **Favorites semantics:** Star control is a toggle; long-term use
+   `aria-pressed` (already partially modeled) and persist announcement of state
+   change via snackbar `polite` live region if needed.
+7. **"More options" menu:** Control is non-functional; when a menu is wired, use
+   `mat-menu` with `aria-haspopup` / `aria-expanded`.
+
+## Out of scope
+
+- Full Material 3 redesign of Labs.
+- Removing or default-enabling the Labs experimental flag.
+- Automated a11y CI (axe in browser tests) — useful follow-up, not required here.

--- a/frontend/app/components/labs/labs.ng.html
+++ b/frontend/app/components/labs/labs.ng.html
@@ -34,8 +34,8 @@
             <mat-icon class="material-symbols-outlined">edit_note</mat-icon>
             <span>Save Draft</span>
           </button>
-          <button class="playground-discard-btn" (click)="setActiveView('experiments')" title="Discard changes">
-            <mat-icon class="material-symbols-outlined">delete_outline</mat-icon>
+          <button class="playground-discard-btn" (click)="setActiveView('experiments')" title="Discard changes" aria-label="Discard changes">
+            <mat-icon class="material-symbols-outlined" aria-hidden="true">delete_outline</mat-icon>
           </button>
         }
       </div>
@@ -59,7 +59,12 @@
           <!-- Filter Chips (Left) -->
           <div class="market-filter-chips">
             @for (category of categories; track category) {
-              <button class="filter-chip" [class.active]="selectedCategory() === category" (click)="onCategoryChange(category)">
+              <button
+                class="filter-chip"
+                [class.active]="selectedCategory() === category"
+                [attr.aria-pressed]="selectedCategory() === category"
+                [attr.aria-label]="'Filter experiments by ' + category"
+                (click)="onCategoryChange(category)">
                 {{category}}
               </button>
             }
@@ -73,18 +78,28 @@
                 <input type="text" matInput class="market-search-input" placeholder="Search experiments..." aria-label="Search experiments" [value]="searchQuery()" (input)="onSearchChange($event)">
               </mat-form-field>
               @if (searchQuery()) {
-                <button class="market-search-clear-btn" (click)="clearSearch()" title="Clear search">
-                  <mat-icon class="material-symbols-outlined">close</mat-icon>
+                <button class="market-search-clear-btn" (click)="clearSearch()" title="Clear search" aria-label="Clear search">
+                  <mat-icon class="material-symbols-outlined" aria-hidden="true">close</mat-icon>
                 </button>
               }
             </div>
 
-            <div class="view-toggle-group">
-              <button [class.active]="displayMode() === 'grid'" (click)="setDisplayMode('grid')" title="Grid View">
-                <mat-icon class="material-symbols-outlined">grid_view</mat-icon>
+            <div class="view-toggle-group" role="group" aria-label="Experiment display mode">
+              <button
+                [class.active]="displayMode() === 'grid'"
+                [attr.aria-pressed]="displayMode() === 'grid'"
+                (click)="setDisplayMode('grid')"
+                title="Grid View"
+                aria-label="Grid view">
+                <mat-icon class="material-symbols-outlined" aria-hidden="true">grid_view</mat-icon>
               </button>
-              <button [class.active]="displayMode() === 'list'" (click)="setDisplayMode('list')" title="List View">
-                <mat-icon class="material-symbols-outlined">view_list</mat-icon>
+              <button
+                [class.active]="displayMode() === 'list'"
+                [attr.aria-pressed]="displayMode() === 'list'"
+                (click)="setDisplayMode('list')"
+                title="List View"
+                aria-label="List view">
+                <mat-icon class="material-symbols-outlined" aria-hidden="true">view_list</mat-icon>
               </button>
             </div>
           </div>
@@ -133,8 +148,14 @@
                       <div class="card-icon-box" [ngClass]="tool.colorClass ?? ''">
                         <mat-icon class="material-symbols-outlined">{{tool.icon}}</mat-icon>
                       </div>
-                      <button class="card-fav-btn" [class.favorite]="tool.isFavorite" (click)="toggleFavorite(tool)" title="Add to favorites">
-                        <mat-icon class="material-symbols-outlined">{{tool.isFavorite ? 'star' : 'star_border'}}</mat-icon>
+                      <button
+                        class="card-fav-btn"
+                        [class.favorite]="tool.isFavorite"
+                        [attr.aria-pressed]="!!tool.isFavorite"
+                        [attr.aria-label]="tool.isFavorite ? 'Remove ' + tool.label + ' from favorites' : 'Add ' + tool.label + ' to favorites'"
+                        (click)="toggleFavorite(tool)"
+                        title="Add to favorites">
+                        <mat-icon class="material-symbols-outlined" aria-hidden="true">{{tool.isFavorite ? 'star' : 'star_border'}}</mat-icon>
                       </button>
                     </div>
 
@@ -172,8 +193,8 @@
                   <!-- Card Actions -->
                   <div class="card-actions">
                     <button class="launch-btn" (click)="onLaunchTool(tool)">Launch</button>
-                    <button class="card-more-btn" title="More options">
-                      <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
+                    <button class="card-more-btn" title="More options" [attr.aria-label]="'More options for ' + tool.label">
+                      <mat-icon class="material-symbols-outlined" aria-hidden="true">more_vert</mat-icon>
                     </button>
                   </div>
                 </div>

--- a/labs/curated/memory_analysis/frontend/flame_graph/flame_graph.ng.html
+++ b/labs/curated/memory_analysis/frontend/flame_graph/flame_graph.ng.html
@@ -1,10 +1,10 @@
 <div class="flame-graph-container">
   <div class="toolbar-row">
-    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="zoomOut()" matTooltip="Zoom Out">
-      <mat-icon>arrow_upward</mat-icon>
+    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="zoomOut()" matTooltip="Zoom Out" aria-label="Zoom out flame graph">
+      <mat-icon aria-hidden="true">arrow_upward</mat-icon>
     </button>
-    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="resetZoom()" matTooltip="Reset Zoom">
-      <mat-icon>home</mat-icon>
+    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="resetZoom()" matTooltip="Reset Zoom" aria-label="Reset flame graph zoom">
+      <mat-icon aria-hidden="true">home</mat-icon>
     </button>
     @if (zoomStack().length > 1) {
       <span class="breadcrumbs">

--- a/labs/curated/memory_analysis/frontend/memory_analysis.ng.html
+++ b/labs/curated/memory_analysis/frontend/memory_analysis.ng.html
@@ -1,15 +1,21 @@
 <div class="memory-analysis-container" [class.sidebar-collapsed]="!sidebarExpanded()">
   @if (loading()) {
     <div class="loading-overlay">
-      <mat-spinner diameter="48"></mat-spinner>
+      <mat-spinner diameter="48" aria-label="Loading memory analysis"></mat-spinner>
     </div>
   }
 
   <div class="main-content-area">
     <!-- Top Controls Row -->
     <div class="top-controls-row">
-      <button mat-icon-button (click)="toggleSidebar()" matTooltip="Toggle Sidebar" class="sidebar-toggle-btn">
-        <mat-icon>{{sidebarExpanded() ? 'menu_open' : 'menu'}}</mat-icon>
+      <button
+        mat-icon-button
+        (click)="toggleSidebar()"
+        matTooltip="Toggle Sidebar"
+        class="sidebar-toggle-btn"
+        [attr.aria-label]="sidebarExpanded() ? 'Collapse memory breakdown sidebar' : 'Expand memory breakdown sidebar'"
+        [attr.aria-expanded]="sidebarExpanded()">
+        <mat-icon aria-hidden="true">{{sidebarExpanded() ? 'menu_open' : 'menu'}}</mat-icon>
       </button>
 
       @if (moduleList.length > 1) {

--- a/labs/curated/memory_analysis/frontend/treemap/treemap.ng.html
+++ b/labs/curated/memory_analysis/frontend/treemap/treemap.ng.html
@@ -1,10 +1,10 @@
 <div class="treemap-container">
   <div class="toolbar-row">
-    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="zoomOut()" matTooltip="Zoom Out">
-      <mat-icon>arrow_upward</mat-icon>
+    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="zoomOut()" matTooltip="Zoom Out" aria-label="Zoom out treemap">
+      <mat-icon aria-hidden="true">arrow_upward</mat-icon>
     </button>
-    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="resetZoom()" matTooltip="Reset Zoom">
-      <mat-icon>home</mat-icon>
+    <button mat-icon-button [disabled]="zoomStack().length <= 1" (click)="resetZoom()" matTooltip="Reset Zoom" aria-label="Reset treemap zoom">
+      <mat-icon aria-hidden="true">home</mat-icon>
     </button>
     @if (zoomStack().length > 1) {
       <span class="breadcrumbs">


### PR DESCRIPTION
## Summary

FIX-041 follow-up for the experimental XProf Labs Material UI (#2892):

- Add `frontend/app/components/labs/a11y_checklist.md` with smoke-pass steps, filled checklist, critical fixes, and remaining a11y debt (tabs ARIA pattern, focus management, SVG keyboard, contrast audit).
- Label obvious icon-only controls and expose toggle state on filter chips / view mode / favorites so assistive tech gets name + pressed state.
- Same easy labels on Memory Analysis sidebar toggle, loading spinner, and flame/treemap zoom controls under `labs/`.

Labs remains behind the existing experimental enable gate; no redesign.

## Test plan

- [ ] Review checklist doc for accuracy against current Labs templates
- [ ] Keyboard: Tab through Labs marketplace (chips, search clear, grid/list, favorite, more) and confirm controls announce names in AT if available
- [ ] Open Memory Analysis (when Labs enabled): sidebar toggle + zoom buttons have accessible names
- [ ] Confirm no visual/layout regressions (aria-only attributes)