### PR TITLE
Prevent zero-height Trace Viewer v2 label resizer

### DIFF
--- a/frontend/app/components/trace_viewer_v2/timeline/timeline.cc
+++ b/frontend/app/components/trace_viewer_v2/timeline/timeline.cc
@@ -718,19 +718,24 @@ void Timeline::Draw() {
   ImGui::Dummy(ImVec2(content_region_avail_width, 1.0f));
 
   // Handle label resizing manually since we removed the table
-  ImGui::SetCursorPos(ImVec2(
-      tracks_start_pos.x + label_width_ - kSplitterOffset, tracks_start_pos.y));
-  ImGui::InvisibleButton("##LabelResizer",
-                         ImVec2(kSplitterWidth, group_offsets_.back()));
-  if (ImGui::IsItemActive()) {
-    label_width_ += ImGui::GetIO().MouseDelta.x;
-    label_width_ = std::max(10.0f, label_width_);
-    is_resizing_label_column_ = true;
+  if (group_offsets_.back() > 0.0f) {
+    ImGui::SetCursorPos(
+        ImVec2(tracks_start_pos.x + label_width_ - kSplitterOffset,
+               tracks_start_pos.y));
+    ImGui::InvisibleButton("##LabelResizer",
+                           ImVec2(kSplitterWidth, group_offsets_.back()));
+    if (ImGui::IsItemActive()) {
+      label_width_ += ImGui::GetIO().MouseDelta.x;
+      label_width_ = std::max(10.0f, label_width_);
+      is_resizing_label_column_ = true;
+    } else {
+      is_resizing_label_column_ = false;
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+    }
   } else {
     is_resizing_label_column_ = false;
-  }
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
   }
 
   HandleEventDeselection();


### PR DESCRIPTION
## Summary

- skip the timeline label-resizer hit target while the track-group height is zero
- keep the resizing state inactive until the timeline has drawable height
- preserve existing resize behavior after tracks are laid out

## Why

During initial layout, `group_offsets_.back()` can be zero. Passing that height to `ImGui::InvisibleButton` violates ImGui's non-zero-size assertion and aborts the WebAssembly Trace Viewer v2 runtime.

## Validation

- built the XProf wheel successfully from current `master` plus this change
- loaded the profile that previously reproduced the assertion in Trace Viewer v2
- confirmed the timeline rendered with no ImGui `InvisibleButton` assertion or WebAssembly abort