### PR TITLE
[ROCm] Make roofline GPU detection vendor-neutral

### DIFF
--- a/frontend/app/components/roofline_model/roofline_model.ts
+++ b/frontend/app/components/roofline_model/roofline_model.ts
@@ -38,7 +38,7 @@ interface TooltipRow {
   operation?: (val: string | number) => string;
 }
 
-const NVIDIA_GPU_TYPE_PREFIX = 'Nvidia GPU';
+const GPU_TYPE_SUBSTRING = 'GPU';
 
 /** A roofline model component. */
 @Component({
@@ -259,7 +259,7 @@ export class RooflineModel implements OnDestroy {
       hasCmem: !!Number(dataTableRaw.getTableProperty('has_cmem')),
       hasMegacore: !!Number(dataTableRaw.getTableProperty('megacore')),
       isGpu: dataTableRaw.getTableProperty('device_type')
-                 .startsWith(NVIDIA_GPU_TYPE_PREFIX),
+                 .includes(GPU_TYPE_SUBSTRING),
       timeScaleMultiplier:
           Number(dataTableRaw.getTableProperty('time_scale_multiplier')) || 1,
     };


### PR DESCRIPTION
On an AMD (ROCm) profile trace, the Roofline Model tool renders TPU vocabulary and a TPU layout.

The device panel reads "Peak FLOP Rate per TensorCore", "Megacore: No", and lists VMEM Read/Write and CMEM bandwidth rows. The chart draws only an HBM roofline.
<img width="1216" height="173" alt="image" src="https://github.com/user-attachments/assets/5e5e243d-bc41-48c0-8f20-85423706cf2c" />
<img width="441" height="264" alt="image" src="https://github.com/user-attachments/assets/32c4b6b1-9e3f-4419-8962-05619c1faa84" />

!!! POST MERGE EDIT:
The above screenshot is inaccurate and was showing a cached XProf build with seperate in-flight changes I was working on. The true roofline page BEFORE this PR landed is shown below (v2.23.1):
<img width="1227" height="752" alt="image" src="https://github.com/user-attachments/assets/7ec27a91-2c79-4e9c-bb8b-f059e16de795" />




The same page on an NVIDIA trace renders correctly: "per GPU" labels, no Megacore row, and both a "Shared Mem / L1 Roofline" and an "HBM Roofline".
<img width="398" height="130" alt="image" src="https://github.com/user-attachments/assets/f874e097-8e03-46e1-910c-9cb1152773a9" />
<img width="477" height="265" alt="image" src="https://github.com/user-attachments/assets/801b8f86-d1ba-4595-928a-4e679bd9911a" />


### Root cause

The component derives a single `isGpu` flag from a vendor-specific prefix:

```ts
// frontend/app/components/roofline_model/roofline_model.ts:41
const NVIDIA_GPU_TYPE_PREFIX = 'Nvidia GPU';

// :261-262
isGpu: dataTableRaw.getTableProperty('device_type')
           .startsWith(NVIDIA_GPU_TYPE_PREFIX),
```

`device_type` comes from `GpuModelName()` (`xprof/utils/hardware_type_utils.cc:315`), which returns `"AMD GPU - gfx-9XX series"` for ROCm traces. That fails the `startsWith` test, so `isGpu` is false and the component takes the TPU branch for labels (`:273-290`), the base series (`:762`), the roofline rows (`:816-848`), the tooltip schema (`:1173`) and the series styles (`:1194`).

Every other GPU test in the pipeline is vendor-neutral, which is why the backend hands the frontend a GPU-shaped table that the frontend then renders as a TPU:

- `ParseHardwareType` — `xprof/utils/hardware_type_utils.cc:362` — `StrContains(device_type, "GPU")`
- `GenerateRooflineModelDataTable` — `xprof/convert/op_stats_to_roofline_model.cc:606` — `StrContains(..., "GPU")`
- `xprof/convert/op_stats_to_tf_stats.cc:165,193` — `StrContains(device_type, "GPU")`
- `xprof/convert/op_stats_to_overview_page.cc:843` — `StrContains(hardware_type, "GPU")`
- `frontend/.../pod_viewer/pod_viewer_common.ts:252` — already uses `.includes('GPU')`

### Fix

Match the neutral substring test the rest of the pipeline already uses:

```diff
-const NVIDIA_GPU_TYPE_PREFIX = 'Nvidia GPU';
+const GPU_TYPE_SUBSTRING = 'GPU';

       isGpu: dataTableRaw.getTableProperty('device_type')
-                 .startsWith(NVIDIA_GPU_TYPE_PREFIX),
+                 .includes(GPU_TYPE_SUBSTRING),
```

<img width="486" height="596" alt="image" src="https://github.com/user-attachments/assets/7a89359a-701c-4e33-95d7-bf280ff8c87d" />

POST MERGE EDIT:
The above screenshot is inaccurate and was showing a cached XProf build with seperate in-flight changes I was working on. The true roofline page AFTER this PR landed is shown below:
<img width="960" height="776" alt="image" src="https://github.com/user-attachments/assets/8a7ca857-f74b-448c-a78d-63f713804a68" />




### Environment

XProf 2.22.3. AMD 8x MI300X (gfx942) profiled via JAX.

---

### Secondary issue with Shared Mem / L1 value

This change causes the Shared Mem / L1 roofline to be drawn on AMD, and the value it
draws is incorrect. The peak is derived from an NVIDIA-specific model with no
vendor gate:

```cpp
// xprof/convert/xplane_to_op_stats.cc:136-138
double shm_giga_bytes_per_second =
    cap.num_cores() *
    tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(cap));
```

GetSharedMemoryBandwidthPerSM(cap) being the NVIDIA specific calculation.

---

Hope this is reasonable. I am new to contributing so I'm happy to take any advice. Thanks.