### PR TITLE
[ROCm] Fix the Roofline Analysis peak FLOP rate and LDS bandwidth models for AMD GPUs

### DIFF
--- a/plugin/xprof/protobuf/hardware_types.proto
+++ b/plugin/xprof/protobuf/hardware_types.proto
@@ -28,4 +28,5 @@ message DeviceCapabilities {
   uint64 memory_bandwidth = 4;  // Bytes/s.
   GPUComputeCapability compute_capability = 5;
   string device_vendor = 6;
+  string device_name = 7;
 }

--- a/xprof/convert/xplane_to_op_stats.cc
+++ b/xprof/convert/xplane_to_op_stats.cc
@@ -222,10 +222,9 @@ void SetRunEnvironment(const XSpace& space, RunEnvironment* env) {
   std::vector<const XPlane*> gpu_planes =
       FindPlanesWithPrefix(space, kGpuPlanePrefix);
   if (!gpu_planes.empty()) {
-    absl::string_view gpu_model =
-        GpuModelName(GetDeviceCaps(*gpu_planes.front()));
+    std::string gpu_model = GpuModelName(GetDeviceCaps(*gpu_planes.front()));
     if (!gpu_model.empty()) {
-      env->set_device_type(std::string(gpu_model));
+      env->set_device_type(std::move(gpu_model));
     } else {
       env->set_device_type("GPU");
     }

--- a/xprof/convert/xplane_to_op_stats.cc
+++ b/xprof/convert/xplane_to_op_stats.cc
@@ -142,13 +142,13 @@ PerfEnv GetPerfEnvFromXPlane(const XPlane& device_plane) {
     if (peak_tera_flops_per_second <= 0.0) {
       peak_tera_flops_per_second =
           cap.num_cores() *
-          tsl::profiler::GigaToTera(GetFlopMaxThroughputPerSM(cap));
+          tsl::profiler::GigaToTera(GetFlopMaxThroughputPerCore(cap));
     }
     double hbm_bw_giga_bytes_per_second =
         tsl::profiler::UniToGiga(cap.memory_bandwidth());
     double derived_shm_giga_bytes_per_second =
         cap.num_cores() *
-        tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(cap));
+        tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerCore(cap));
     // Note that treat SRAM_RD and SRAM_WR as the same. So in future, we could
     // only use one for shared memory / L1 cache, one for another like L2.
     double sram_rd_giga_bytes_per_second = GetDoubleStatOrZero(

--- a/xprof/convert/xplane_to_op_stats.cc
+++ b/xprof/convert/xplane_to_op_stats.cc
@@ -94,6 +94,11 @@ std::string Hostname(const XSpace& space) {
   return hostname;
 }
 
+double GetDoubleStatOrZero(const XPlaneVisitor& visitor, StatType stat_type) {
+  std::optional<XStatVisitor> stat = visitor.GetStat(stat_type);
+  return stat.has_value() ? stat->DoubleValue() : 0.0;
+}
+
 }  // namespace
 
 PerfEnv MakePerfEnv(double peak_tera_flops_per_second,
@@ -128,20 +133,38 @@ PerfEnv MakePerfEnvForGpu(double peak_tera_flops_per_second,
 PerfEnv GetPerfEnvFromXPlane(const XPlane& device_plane) {
   DeviceCapabilities cap = GetDeviceCaps(device_plane);
   if (!absl::StartsWith(device_plane.name(), kTpuPlanePrefix)) {
+    XPlaneVisitor visitor = tsl::profiler::CreateTfXPlaneVisitor(&device_plane);
+    // An XLA profiler backend may populate the stat in the XPlane directly, as
+    // libtpu does for TPU. If so, prefer the provided stat, as in future XLA GPU
+    // backends may choose to provide it directly too.
     double peak_tera_flops_per_second =
-        cap.num_cores() *
-        tsl::profiler::GigaToTera(GetFlopMaxThroughputPerSM(cap));
+        GetDoubleStatOrZero(visitor, StatType::kDevCapPeakTeraflopsPerSecond);
+    if (peak_tera_flops_per_second <= 0.0) {
+      peak_tera_flops_per_second =
+          cap.num_cores() *
+          tsl::profiler::GigaToTera(GetFlopMaxThroughputPerSM(cap));
+    }
     double hbm_bw_giga_bytes_per_second =
         tsl::profiler::UniToGiga(cap.memory_bandwidth());
-    double shm_giga_bytes_per_second =
+    double derived_shm_giga_bytes_per_second =
         cap.num_cores() *
         tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(cap));
     // Note that treat SRAM_RD and SRAM_WR as the same. So in future, we could
     // only use one for shared memory / L1 cache, one for another like L2.
+    double sram_rd_giga_bytes_per_second = GetDoubleStatOrZero(
+        visitor, StatType::kDevCapPeakSramRdBwGigabytesPerSecond);
+    double sram_wr_giga_bytes_per_second = GetDoubleStatOrZero(
+        visitor, StatType::kDevCapPeakSramWrBwGigabytesPerSecond);
+    if (sram_rd_giga_bytes_per_second <= 0.0) {
+      sram_rd_giga_bytes_per_second = derived_shm_giga_bytes_per_second;
+    }
+    if (sram_wr_giga_bytes_per_second <= 0.0) {
+      sram_wr_giga_bytes_per_second = derived_shm_giga_bytes_per_second;
+    }
     return MakePerfEnvForGpu(peak_tera_flops_per_second,
                              {/*HBM_RW=*/hbm_bw_giga_bytes_per_second,
-                              /*SRAM_RD=*/shm_giga_bytes_per_second,
-                              /*SRAM_WR=*/shm_giga_bytes_per_second});
+                              /*SRAM_RD=*/sram_rd_giga_bytes_per_second,
+                              /*SRAM_WR=*/sram_wr_giga_bytes_per_second});
   } else {
     XPlaneVisitor visitor = tsl::profiler::CreateTfXPlaneVisitor(&device_plane);
     std::optional<XStatVisitor> peak_tera_flops_per_second =

--- a/xprof/convert/xplane_to_op_stats_test.cc
+++ b/xprof/convert/xplane_to_op_stats_test.cc
@@ -119,51 +119,42 @@ TEST(ConvertXPlaneToOpStats, GpuPerfEnv) {
   EXPECT_NEAR(139.26, perf_env.ridge_point(), kMaxError);
 }
 
-// MI300X: 304 CU at 2.1 GHz, 5.3 TB/s HBM. The built-in tables derive
-// 1307.44 TFLOP/s and 81715.2 GB/s of LDS from this.
-void SetMi300xDeviceCaps(XPlane* plane) {
-  XPlaneBuilder device_plane(plane);
-  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata(
-                                GetStatTypeStr(StatType::kDevVendor)),
-                            kDeviceVendorAMD);
-  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata(
-                                GetStatTypeStr(StatType::kGpuDeviceName)),
-                            "gfx942");
-  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata("clock_rate"),
-                            2100000);
-  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata("core_count"),
-                            304);
-  device_plane.AddStatValue(
-      *device_plane.GetOrCreateStatMetadata("memory_bandwidth"),
-      uint64_t{5300} * 1000 * 1000 * 1000);
-}
-
-void SetBackendPeakStats(XPlane* plane, double tera_flops, double sram_rd,
-                         double sram_wr) {
-  XPlaneBuilder device_plane(plane);
-  device_plane.AddStatValue(
-      *device_plane.GetOrCreateStatMetadata(
-          GetStatTypeStr(StatType::kDevCapPeakTeraflopsPerSecond)),
-      tera_flops);
-  device_plane.AddStatValue(
-      *device_plane.GetOrCreateStatMetadata(
-          GetStatTypeStr(StatType::kDevCapPeakSramRdBwGigabytesPerSecond)),
-      sram_rd);
-  device_plane.AddStatValue(
-      *device_plane.GetOrCreateStatMetadata(
-          GetStatTypeStr(StatType::kDevCapPeakSramWrBwGigabytesPerSecond)),
-      sram_wr);
-}
-
 TEST(ConvertXPlaneToOpStats, GpuPerfEnvPrefersBackendPeaks) {
   constexpr double kMaxError = 0.01;
   XSpace space;
+  // MI300X: 304 CU at 2.1 GHz, 5.3 TB/s HBM.
   XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
-  SetMi300xDeviceCaps(device_plane);
-  SetBackendPeakStats(device_plane, /*tera_flops=*/1250.0,
-                      /*sram_rd=*/65000.0, /*sram_wr=*/48000.0);
+  XPlaneBuilder device_plane_builder(device_plane);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevVendor)),
+      kDeviceVendorAMD);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kGpuDeviceName)),
+      "gfx942");
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("clock_rate"), 2100000);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("core_count"), 304);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("memory_bandwidth"),
+      uint64_t{5300} * 1000 * 1000 * 1000);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakTeraflopsPerSecond)),
+      1250.0);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramRdBwGigabytesPerSecond)),
+      65000.0);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramWrBwGigabytesPerSecond)),
+      48000.0);
 
   PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
+  // Reported over the 1307.44 TFLOP/s and 81715.2 GB/s the tables derive.
   EXPECT_NEAR(1250.0, perf_env.peak_tera_flops_per_second(), kMaxError);
   EXPECT_NEAR(
       65000.0,
@@ -183,10 +174,27 @@ TEST(ConvertXPlaneToOpStats, GpuPerfEnvPrefersBackendPeaks) {
 TEST(ConvertXPlaneToOpStats, GpuPerfEnvDerivesPeaksWithoutBackendStats) {
   constexpr double kMaxError = 0.01;
   XSpace space;
+  // MI300X: 304 CU at 2.1 GHz, 5.3 TB/s HBM.
   XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
-  SetMi300xDeviceCaps(device_plane);
+  XPlaneBuilder device_plane_builder(device_plane);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevVendor)),
+      kDeviceVendorAMD);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kGpuDeviceName)),
+      "gfx942");
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("clock_rate"), 2100000);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("core_count"), 304);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("memory_bandwidth"),
+      uint64_t{5300} * 1000 * 1000 * 1000);
 
   PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
+  // 304 CU x 2048 FLOP/clock, and 304 CU x 128 LDS B/clock, at 2.1 GHz.
   EXPECT_NEAR(1307.44, perf_env.peak_tera_flops_per_second(), kMaxError);
   // Read and write both fall back to the one derived LDS figure.
   EXPECT_NEAR(
@@ -202,10 +210,37 @@ TEST(ConvertXPlaneToOpStats, GpuPerfEnvDerivesPeaksWithoutBackendStats) {
 TEST(ConvertXPlaneToOpStats, GpuPerfEnvDerivesPeaksWhenBackendReportsZero) {
   constexpr double kMaxError = 0.01;
   XSpace space;
+  // MI300X: 304 CU at 2.1 GHz, 5.3 TB/s HBM.
   XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
-  SetMi300xDeviceCaps(device_plane);
-  SetBackendPeakStats(device_plane, /*tera_flops=*/0.0, /*sram_rd=*/0.0,
-                      /*sram_wr=*/0.0);
+  XPlaneBuilder device_plane_builder(device_plane);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevVendor)),
+      kDeviceVendorAMD);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kGpuDeviceName)),
+      "gfx942");
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("clock_rate"), 2100000);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("core_count"), 304);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata("memory_bandwidth"),
+      uint64_t{5300} * 1000 * 1000 * 1000);
+  // A stat that is present but zero must fall back just as an absent one does.
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakTeraflopsPerSecond)),
+      0.0);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramRdBwGigabytesPerSecond)),
+      0.0);
+  device_plane_builder.AddStatValue(
+      *device_plane_builder.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramWrBwGigabytesPerSecond)),
+      0.0);
 
   PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
   EXPECT_NEAR(1307.44, perf_env.peak_tera_flops_per_second(), kMaxError);

--- a/xprof/convert/xplane_to_op_stats_test.cc
+++ b/xprof/convert/xplane_to_op_stats_test.cc
@@ -54,6 +54,7 @@ using ::tsl::profiler::GetOrCreateGpuXPlane;
 using ::tsl::profiler::GetOrCreateHostXPlane;
 using ::tsl::profiler::GetOrCreateTpuXPlane;
 using ::tsl::profiler::HostEventType;
+using ::tsl::profiler::kDeviceVendorAMD;
 using ::tsl::profiler::kDeviceVendorNvidia;
 using ::tsl::profiler::kSparseCoreModuleLineName;
 using ::tsl::profiler::kSparseCoreOpLineName;
@@ -116,6 +117,106 @@ TEST(ConvertXPlaneToOpStats, GpuPerfEnv) {
       kMaxError);
   // Ridge point changed accordingly from above peak flops change.
   EXPECT_NEAR(139.26, perf_env.ridge_point(), kMaxError);
+}
+
+// MI300X: 304 CU at 2.1 GHz, 5.3 TB/s HBM. The built-in tables derive
+// 1307.44 TFLOP/s and 81715.2 GB/s of LDS from this.
+void SetMi300xDeviceCaps(XPlane* plane) {
+  XPlaneBuilder device_plane(plane);
+  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata(
+                                GetStatTypeStr(StatType::kDevVendor)),
+                            kDeviceVendorAMD);
+  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata(
+                                GetStatTypeStr(StatType::kGpuDeviceName)),
+                            "gfx942");
+  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata("clock_rate"),
+                            2100000);
+  device_plane.AddStatValue(*device_plane.GetOrCreateStatMetadata("core_count"),
+                            304);
+  device_plane.AddStatValue(
+      *device_plane.GetOrCreateStatMetadata("memory_bandwidth"),
+      uint64_t{5300} * 1000 * 1000 * 1000);
+}
+
+void SetBackendPeakStats(XPlane* plane, double tera_flops, double sram_rd,
+                         double sram_wr) {
+  XPlaneBuilder device_plane(plane);
+  device_plane.AddStatValue(
+      *device_plane.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakTeraflopsPerSecond)),
+      tera_flops);
+  device_plane.AddStatValue(
+      *device_plane.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramRdBwGigabytesPerSecond)),
+      sram_rd);
+  device_plane.AddStatValue(
+      *device_plane.GetOrCreateStatMetadata(
+          GetStatTypeStr(StatType::kDevCapPeakSramWrBwGigabytesPerSecond)),
+      sram_wr);
+}
+
+TEST(ConvertXPlaneToOpStats, GpuPerfEnvPrefersBackendPeaks) {
+  constexpr double kMaxError = 0.01;
+  XSpace space;
+  XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
+  SetMi300xDeviceCaps(device_plane);
+  SetBackendPeakStats(device_plane, /*tera_flops=*/1250.0,
+                      /*sram_rd=*/65000.0, /*sram_wr=*/48000.0);
+
+  PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
+  EXPECT_NEAR(1250.0, perf_env.peak_tera_flops_per_second(), kMaxError);
+  EXPECT_NEAR(
+      65000.0,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_RD),
+      kMaxError);
+  EXPECT_NEAR(
+      48000.0,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_WR),
+      kMaxError);
+  // HBM has no backend stat on the GPU path, so it still comes from the caps.
+  EXPECT_NEAR(
+      5300.0,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_HBM_RW),
+      kMaxError);
+}
+
+TEST(ConvertXPlaneToOpStats, GpuPerfEnvDerivesPeaksWithoutBackendStats) {
+  constexpr double kMaxError = 0.01;
+  XSpace space;
+  XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
+  SetMi300xDeviceCaps(device_plane);
+
+  PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
+  EXPECT_NEAR(1307.44, perf_env.peak_tera_flops_per_second(), kMaxError);
+  // Read and write both fall back to the one derived LDS figure.
+  EXPECT_NEAR(
+      81715.2,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_RD),
+      kMaxError);
+  EXPECT_NEAR(
+      81715.2,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_WR),
+      kMaxError);
+}
+
+TEST(ConvertXPlaneToOpStats, GpuPerfEnvDerivesPeaksWhenBackendReportsZero) {
+  constexpr double kMaxError = 0.01;
+  XSpace space;
+  XPlane* device_plane = GetOrCreateGpuXPlane(&space, /*device_ordinal=*/0);
+  SetMi300xDeviceCaps(device_plane);
+  SetBackendPeakStats(device_plane, /*tera_flops=*/0.0, /*sram_rd=*/0.0,
+                      /*sram_wr=*/0.0);
+
+  PerfEnv perf_env = GetPerfEnvFromXPlane(*device_plane);
+  EXPECT_NEAR(1307.44, perf_env.peak_tera_flops_per_second(), kMaxError);
+  EXPECT_NEAR(
+      81715.2,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_RD),
+      kMaxError);
+  EXPECT_NEAR(
+      81715.2,
+      perf_env.peak_bws_giga_bytes_per_second(MemBwType::MEM_BW_TYPE_SRAM_WR),
+      kMaxError);
 }
 
 TEST(ConvertXPlaneToOpStats, GpuRunEnvironment) {

--- a/xprof/utils/BUILD
+++ b/xprof/utils/BUILD
@@ -70,15 +70,40 @@ cc_test(
 )
 
 cc_library(
-    name = "hardware_type_utils",
-    srcs = ["hardware_type_utils.cc"],
-    hdrs = ["hardware_type_utils.h"],
+    name = "cuda_type_utils",
+    srcs = ["cuda_type_utils.cc"],
+    hdrs = ["cuda_type_utils.h"],
+    deps = [
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/log",
+        "@org_xprof//plugin/xprof/protobuf:hardware_types_proto_cc",
+        "@xla//xla/tsl/profiler/utils:math_utils",
+    ],
+)
+
+cc_library(
+    name = "rocm_type_utils",
+    srcs = ["rocm_type_utils.cc"],
+    hdrs = ["rocm_type_utils.h"],
     deps = [
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@org_xprof//plugin/xprof/protobuf:hardware_types_proto_cc",
         "@xla//xla/tsl/profiler/utils:math_utils",
+    ],
+)
+
+cc_library(
+    name = "hardware_type_utils",
+    srcs = ["hardware_type_utils.cc"],
+    hdrs = ["hardware_type_utils.h"],
+    deps = [
+        ":cuda_type_utils",
+        ":rocm_type_utils",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@org_xprof//plugin/xprof/protobuf:hardware_types_proto_cc",
         "@xla//xla/tsl/profiler/utils:xplane_schema",
     ],
 )

--- a/xprof/utils/cuda_type_utils.cc
+++ b/xprof/utils/cuda_type_utils.cc
@@ -1,0 +1,368 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xprof/utils/cuda_type_utils.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+
+#include "absl/container/btree_map.h"
+#include "absl/log/log.h"
+#include "xla/tsl/profiler/utils/math_utils.h"
+#include "plugin/xprof/protobuf/hardware_types.pb.h"
+
+namespace tensorflow {
+namespace profiler {
+namespace cuda {
+namespace {
+
+struct GpuFlopCapabilities {
+  struct FlopCapabilityOnPrecisions {
+    double fp64_tflops = 0;
+    double fp32_tflops = 0;  // also for tf32 for nvidia tensor core
+    double bf16_tflops = 0;
+    double fp16_tflops = 0;
+    double fp8_tflops = 0;
+    double int8_tops = 0;
+    double fp4_tflops = 0;
+    double int4_tops = 0;
+
+    void ScaleWith(double scale) {
+      fp64_tflops *= scale;
+      fp32_tflops *= scale;
+      bf16_tflops *= scale;
+      fp16_tflops *= scale;
+      fp8_tflops *= scale;
+      int8_tops *= scale;
+      fp4_tflops *= scale;
+      int4_tops *= scale;
+    }
+  };
+
+  FlopCapabilityOnPrecisions cuda_core;
+  FlopCapabilityOnPrecisions tensor_core;
+  bool has_tensor_core_sparsity_support = false;
+
+  void ScaleWith(double scale) {
+    cuda_core.ScaleWith(scale);
+    tensor_core.ScaleWith(scale);
+  }
+};
+
+// The calculation methods is referred from Nvidia developer forum:
+// https://forums.developer.nvidia.com/t/how-to-calculate-the-tensor-core-fp16-performance-of-h100/244727
+// Below data are calculated from the various NVidia whitepapers/specs.
+
+// https://resources.nvidia.com/en-us-blackwell-architecture?ncid=pa-srch-goog-585983-Intel-Brand-Broad
+// Dense Compute as default.
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_10_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 148,
+            .fp32_tflops = 296,
+            .bf16_tflops = 592,
+            .fp16_tflops = 592,
+            .int8_tops = 1184,
+        },
+    .tensor_core =
+        {
+            .fp64_tflops = 148,
+            .fp32_tflops = 4096,
+            .bf16_tflops = 8192,
+            .fp16_tflops = 8192,
+            .fp8_tflops = 16384,
+            .int8_tops = 16384,
+        },
+    .has_tensor_core_sparsity_support = true,
+};
+
+// https://resources.nvidia.com/en-us-tensor-core/gtc22-whitepaper-hopper
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_9_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 128,
+            .fp32_tflops = 256,
+            .bf16_tflops = 512,
+            .fp16_tflops = 512,
+            .int8_tops = 1024,
+        },
+    .tensor_core =
+        {
+            .fp64_tflops = 256,
+            .fp32_tflops = 2048,
+            .bf16_tflops = 4096,
+            .fp16_tflops = 4096,
+            .fp8_tflops = 8192,
+            .int8_tops = 8192,
+        },
+    .has_tensor_core_sparsity_support = true,
+};
+
+// https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_9 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 128,
+            .fp32_tflops = 256,
+            .bf16_tflops = 256,
+            .fp16_tflops = 256,
+            .int8_tops = 512,
+        },
+    .tensor_core =
+        {
+            .fp32_tflops = 512,
+            .bf16_tflops = 1024,
+            .fp16_tflops = 1024,
+            .fp8_tflops = 2048,
+            .int8_tops = 2048,
+            .int4_tops = 4096,
+        },
+    .has_tensor_core_sparsity_support = true,
+};
+
+// https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_6 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 128,
+            .fp32_tflops = 256,
+            .bf16_tflops = 256,
+            .fp16_tflops = 256,
+            .int8_tops = 512,
+        },
+    .tensor_core =
+        {
+            .fp32_tflops = 256,
+            .bf16_tflops = 512,
+            .fp16_tflops = 1024,
+            .int8_tops = 2048,
+            .int4_tops = 4096,
+        },
+    .has_tensor_core_sparsity_support = true,
+};
+
+// https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 64,
+            .fp32_tflops = 128,
+            .bf16_tflops = 256,
+            .fp16_tflops = 512,
+            .int8_tops = 512,
+        },
+    .tensor_core =
+        {
+            .fp64_tflops = 128,
+            .fp32_tflops = 1024,
+            .bf16_tflops = 2048,
+            .fp16_tflops = 2048,
+            .int8_tops = 4096,
+        },
+    .has_tensor_core_sparsity_support = true,
+};
+
+// https://images.nvidia.com/aem-dam/en-zz/Solutions/design-visualization/technologies/turing-architecture/NVIDIA-Turing-Architecture-Whitepaper.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_5 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 64,
+            .fp32_tflops = 128,
+            .fp16_tflops = 256,
+            .int8_tops = 512,
+        },
+    .tensor_core =
+        {
+            .fp16_tflops = 1024,
+            .int8_tops = 2048,
+            .int4_tops = 4096,
+        },
+    .has_tensor_core_sparsity_support = false,
+};
+
+// https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 64,
+            .fp32_tflops = 128,
+            .bf16_tflops = 0.0,
+            .fp16_tflops = 256,
+            .int8_tops = 512,
+        },
+    .tensor_core =
+        {
+            .fp16_tflops = 1024,
+        },
+    .has_tensor_core_sparsity_support = false,
+};
+
+// https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_1 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 8,
+            .fp32_tflops = 256,
+            .fp16_tflops = 4,
+            .int8_tops = 1024,
+        },
+    .tensor_core = {},
+    .has_tensor_core_sparsity_support = false,
+};
+
+// https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 64,
+            .fp32_tflops = 128,
+            .fp16_tflops = 256,
+            .int8_tops = 512,
+        },
+    .tensor_core = {},
+    .has_tensor_core_sparsity_support = false,
+};
+
+// https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/NVIDIA-Kepler-GK110-GK210-Architecture-Whitepaper.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_5_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 4,
+            .fp32_tflops = 256,
+        },
+    .tensor_core = {},
+    .has_tensor_core_sparsity_support = false,
+};
+
+// https://www.nvidia.com/content/PDF/product-specifications/GeForce_GTX_680_Whitepaper_FINAL.pdf
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_3_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 128,
+            .fp32_tflops = 384,
+        },
+    .tensor_core = {},
+    .has_tensor_core_sparsity_support = false,
+};
+
+const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
+    .cuda_core =
+        {
+            .fp64_tflops = 8,
+            .fp32_tflops = 64,
+        },
+    .tensor_core = {},
+    .has_tensor_core_sparsity_support = false,
+};
+
+GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
+                                                   int minor_comp_cap) {
+  static const auto& kPerSMFlopCapsTable =
+      *new absl::btree_map<int, GpuFlopCapabilities const*>{
+          // TODO: Add newer GPUS when available.
+          {10000, &kComputeCap_PerSM_PerCycle_10_0},
+          {9000, &kComputeCap_PerSM_PerCycle_9_0},
+          {8090, &kComputeCap_PerSM_PerCycle_8_9},
+          {8060, &kComputeCap_PerSM_PerCycle_8_6},
+          {8000, &kComputeCap_PerSM_PerCycle_8_0},
+          {7050, &kComputeCap_PerSM_PerCycle_7_5},
+          {7000, &kComputeCap_PerSM_PerCycle_7_0},
+          {6010, &kComputeCap_PerSM_PerCycle_6_1},
+          {6000, &kComputeCap_PerSM_PerCycle_6_0},
+          {5000, &kComputeCap_PerSM_PerCycle_5_0},
+          {3000, &kComputeCap_PerSM_PerCycle_3_0},
+          {2000, &kComputeCap_PerSM_PerCycle_2_0},
+      };
+
+  // TODO(b/409612464): - Need more discussion on how to handle the case when
+  // the compute cap is not found in above table. Currently we back off to the
+  // highest compute cap less than the given compute cap, or the oldest compute
+  // cap in the table if the given compute cap is even older than it. Another
+  // way is to just report not found and return 0 in GpuFlopCapabilities. Also
+  // more fine-grained back off also could be used.
+  const int normalized_compute_cap =
+      major_comp_cap * 1000 + minor_comp_cap * 10;
+  auto it = kPerSMFlopCapsTable.lower_bound(normalized_compute_cap);
+  if (it == kPerSMFlopCapsTable.end() || it->first > normalized_compute_cap) {
+    if (it != kPerSMFlopCapsTable.begin()) it = std::prev(it);
+    LOG(WARNING) << "GPU compute capability " << major_comp_cap << "."
+                 << minor_comp_cap
+                 << " is not found. Use the highest compute cap known "
+                 << (it->first / 1000) << "." << ((it->first % 1000) / 10)
+                 << " instead.";
+  }
+  return GpuFlopCapabilities(*(it->second));
+}
+
+}  // namespace
+
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap) {
+  GpuFlopCapabilities sm_flops =
+      GetNvidiaFlopCapsPerSMPerCycle(device_cap.compute_capability().major(),
+                                     device_cap.compute_capability().minor());
+  sm_flops.ScaleWith(device_cap.clock_rate_in_ghz());
+  double result = std::max(
+      {sm_flops.cuda_core.fp32_tflops, sm_flops.cuda_core.fp16_tflops,
+       sm_flops.tensor_core.fp32_tflops, sm_flops.tensor_core.fp16_tflops});
+  VLOG(3) << "GetFlopMaxThroughputPerCore get result: " << result << " GFLOPs";
+  return result;
+}
+
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap) {
+  // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm
+  // Compute capability 2.0, each bank has bandwidth of 4 bytes per 2 cycles.
+  // For compute capability 3.0 and above, each bank has bandwidth 8 bytes per
+  // cycle. Each SM has 32 banks.
+  double transaction_byts_per_cycle =
+      device_cap.compute_capability().major() <= 2 ? (32 * 4 / 2) : (32 * 8);
+  double GiBPS = transaction_byts_per_cycle * device_cap.clock_rate_in_ghz();
+  return tsl::profiler::GigaToUni(GiBPS);
+}
+
+std::string GpuModelName(const DeviceCapabilities& device_cap) {
+  switch (device_cap.compute_capability().major()) {
+    case 2:
+      return "Nvidia GPU (Fermi)";
+    case 3:
+      return "Nvidia GPU (Kepler)";
+    case 5:
+      return "Nvidia GPU (Maxwell)";
+    case 6:
+      return "Nvidia GPU (Pascal)";
+    case 7:
+      if (device_cap.compute_capability().minor() < 5) {
+        return "Nvidia GPU (Volta)";
+      } else {
+        return "Nvidia GPU (Turing)";
+      }
+    case 8:
+      if (device_cap.compute_capability().minor() < 9) {
+        return "Nvidia GPU (Ampere)";
+      } else {
+        return "Nvidia GPU (Ada Lovelace)";
+      }
+    case 9:
+      return "Nvidia GPU (Hopper)";
+    case 10:
+      return "Nvidia GPU (Blackwell)";
+    default:
+      return "Nvidia GPU";
+  }
+}
+
+}  // namespace cuda
+}  // namespace profiler
+}  // namespace tensorflow

--- a/xprof/utils/cuda_type_utils.h
+++ b/xprof/utils/cuda_type_utils.h
@@ -1,0 +1,40 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XPROF_UTILS_CUDA_TYPE_UTILS_H_
+#define XPROF_UTILS_CUDA_TYPE_UTILS_H_
+
+#include <string>
+
+#include "plugin/xprof/protobuf/hardware_types.pb.h"
+
+namespace tensorflow {
+namespace profiler {
+namespace cuda {
+
+// Peak throughput in GFLOPs per second per SM, at the reported clock.
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap);
+
+// Shared memory bandwidth in Bytes per second per SM.
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap);
+
+// Microarchitecture family, e.g. "Nvidia GPU (Hopper)".
+std::string GpuModelName(const DeviceCapabilities& device_cap);
+
+}  // namespace cuda
+}  // namespace profiler
+}  // namespace tensorflow
+
+#endif  // XPROF_UTILS_CUDA_TYPE_UTILS_H_

--- a/xprof/utils/device_caps_utils.cc
+++ b/xprof/utils/device_caps_utils.cc
@@ -56,6 +56,12 @@ void SetDeviceCaps(const DeviceCapabilities& caps, XPlane* plane) {
   xplane.AddStatValue(
       *xplane.GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDevVendor)),
       caps.device_vendor());
+  if (!caps.device_name().empty()) {
+    xplane.AddStatValue(
+        *xplane.GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kGpuDeviceName)),
+        caps.device_name());
+  }
 }
 
 DeviceCapabilities GetDeviceCaps(const XPlane& plane) {
@@ -84,6 +90,9 @@ DeviceCapabilities GetDeviceCaps(const XPlane& plane) {
         break;
       case StatType::kDevVendor:
         caps.set_device_vendor(std::string(stat.StrOrRefValue()));
+        break;
+      case StatType::kGpuDeviceName:
+        caps.set_device_name(std::string(stat.StrOrRefValue()));
         break;
     }
   });

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -17,10 +17,12 @@ limitations under the License.
 
 #include <algorithm>
 #include <iterator>
+#include <string>
 
 #include "absl/container/btree_map.h"
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "xla/tsl/profiler/utils/math_utils.h"
 #include "xla/tsl/profiler/utils/xplane_schema.h"
@@ -236,6 +238,19 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
     .has_tensor_core_sparsity_support = false,
 };
 
+// Extracts the AMD architecture from a reported device name.
+//
+// ROCm collector emits rocprofiler-sdk's agent name, composed via
+// fmt::format("gfx{}{}{:x}", major, minor, step), so it is a bare processor name
+// such as "gfx942". See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp:
+// https://github.com/ROCm/rocprofiler-sdk/blob/amd-staging/source/lib/rocprofiler-sdk/agent.cpp#L769-L775
+//
+// HIP's hipDeviceProp_t::gcnArchName instead carries the target-ID form,
+// "gfx942:sramecc+:xnack-", so keep only the processor.
+absl::string_view GfxVersionFromDeviceName(absl::string_view device_name) {
+  return device_name.substr(0, device_name.find(':'));
+}
+
 GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
                                                    int minor_comp_cap) {
   static const auto& kPerSMFlopCapsTable =
@@ -312,7 +327,7 @@ double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap) {
   return tsl::profiler::GigaToUni(GiBPS);
 }
 
-absl::string_view GpuModelName(const DeviceCapabilities& device_cap) {
+std::string GpuModelName(const DeviceCapabilities& device_cap) {
   if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
     switch (device_cap.compute_capability().major()) {
       case 2:
@@ -343,6 +358,10 @@ absl::string_view GpuModelName(const DeviceCapabilities& device_cap) {
         return "Nvidia GPU";
     }
   } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    // Prefer ROCm provided GCN architecture name if provided.
+    // Otherwise, fallback to existing name derivation via major/minor.
+    absl::string_view gfx = GfxVersionFromDeviceName(device_cap.device_name());
+    if (!gfx.empty()) return absl::StrCat("AMD GPU - ", gfx);
     switch (device_cap.compute_capability().major()) {
       case 9:
         return "AMD GPU - gfx-9XX series";

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -460,9 +460,10 @@ std::string GpuModelName(const DeviceCapabilities& device_cap) {
         return "Nvidia GPU";
     }
   } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
-    // Prefer ROCm provided GCN architecture name if provided.
-    // Otherwise, fallback to existing name derivation via major/minor.
-    absl::string_view gfx = GfxVersionFromDeviceName(device_cap.device_name());
+    // Resolved as the roofline tables do, so the reported architecture and the
+    // rates keyed on it never disagree. Falls back to the family below when
+    // neither the device name nor the compute capability identifies one.
+    absl::string_view gfx = ResolveAmdGfxVersion(device_cap);
     if (!gfx.empty()) return absl::StrCat("AMD GPU - ", gfx);
     switch (device_cap.compute_capability().major()) {
       case 9:

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -15,460 +15,50 @@ limitations under the License.
 
 #include "xprof/utils/hardware_type_utils.h"
 
-#include <algorithm>
-#include <iterator>
-#include <optional>
 #include <string>
 
-#include "absl/container/btree_map.h"
 #include "absl/log/log.h"
-#include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
-#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "xla/tsl/profiler/utils/math_utils.h"
 #include "xla/tsl/profiler/utils/xplane_schema.h"
 #include "plugin/xprof/protobuf/hardware_types.pb.h"
+#include "xprof/utils/cuda_type_utils.h"
+#include "xprof/utils/rocm_type_utils.h"
 
 namespace tensorflow {
 namespace profiler {
-namespace {
-
-// The calculation methods is referred from Nvidia developer forum:
-// https://forums.developer.nvidia.com/t/how-to-calculate-the-tensor-core-fp16-performance-of-h100/244727
-// Below data are calculated from the various NVidia whitepapers/specs.
-
-// https://resources.nvidia.com/en-us-blackwell-architecture?ncid=pa-srch-goog-585983-Intel-Brand-Broad
-// Dense Compute as default.
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_10_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 148,
-            .fp32_tflops = 296,
-            .bf16_tflops = 592,
-            .fp16_tflops = 592,
-            .int8_tops = 1184,
-        },
-    .matrix_unit =
-        {
-            .fp64_tflops = 148,
-            .fp32_tflops = 4096,
-            .bf16_tflops = 8192,
-            .fp16_tflops = 8192,
-            .fp8_tflops = 16384,
-            .int8_tops = 16384,
-        },
-    .has_matrix_unit_sparsity_support = true,
-};
-
-// https://resources.nvidia.com/en-us-tensor-core/gtc22-whitepaper-hopper
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_9_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 128,
-            .fp32_tflops = 256,
-            .bf16_tflops = 512,
-            .fp16_tflops = 512,
-            .int8_tops = 1024,
-        },
-    .matrix_unit =
-        {
-            .fp64_tflops = 256,
-            .fp32_tflops = 2048,
-            .bf16_tflops = 4096,
-            .fp16_tflops = 4096,
-            .fp8_tflops = 8192,
-            .int8_tops = 8192,
-        },
-    .has_matrix_unit_sparsity_support = true,
-};
-
-// https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_9 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 128,
-            .fp32_tflops = 256,
-            .bf16_tflops = 256,
-            .fp16_tflops = 256,
-            .int8_tops = 512,
-        },
-    .matrix_unit =
-        {
-            .fp32_tflops = 512,
-            .bf16_tflops = 1024,
-            .fp16_tflops = 1024,
-            .fp8_tflops = 2048,
-            .int8_tops = 2048,
-            .int4_tops = 4096,
-        },
-    .has_matrix_unit_sparsity_support = true,
-};
-
-// https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_6 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 128,
-            .fp32_tflops = 256,
-            .bf16_tflops = 256,
-            .fp16_tflops = 256,
-            .int8_tops = 512,
-        },
-    .matrix_unit =
-        {
-            .fp32_tflops = 256,
-            .bf16_tflops = 512,
-            .fp16_tflops = 1024,
-            .int8_tops = 2048,
-            .int4_tops = 4096,
-        },
-    .has_matrix_unit_sparsity_support = true,
-};
-
-// https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 64,
-            .fp32_tflops = 128,
-            .bf16_tflops = 256,
-            .fp16_tflops = 512,
-            .int8_tops = 512,
-        },
-    .matrix_unit =
-        {
-            .fp64_tflops = 128,
-            .fp32_tflops = 1024,
-            .bf16_tflops = 2048,
-            .fp16_tflops = 2048,
-            .int8_tops = 4096,
-        },
-    .has_matrix_unit_sparsity_support = true,
-};
-
-// https://images.nvidia.com/aem-dam/en-zz/Solutions/design-visualization/technologies/turing-architecture/NVIDIA-Turing-Architecture-Whitepaper.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_5 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 64,
-            .fp32_tflops = 128,
-            .fp16_tflops = 256,
-            .int8_tops = 512,
-        },
-    .matrix_unit =
-        {
-            .fp16_tflops = 1024,
-            .int8_tops = 2048,
-            .int4_tops = 4096,
-        },
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 64,
-            .fp32_tflops = 128,
-            .bf16_tflops = 0.0,
-            .fp16_tflops = 256,
-            .int8_tops = 512,
-        },
-    .matrix_unit =
-        {
-            .fp16_tflops = 1024,
-        },
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_1 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 8,
-            .fp32_tflops = 256,
-            .fp16_tflops = 4,
-            .int8_tops = 1024,
-        },
-    .matrix_unit = {},
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 64,
-            .fp32_tflops = 128,
-            .fp16_tflops = 256,
-            .int8_tops = 512,
-        },
-    .matrix_unit = {},
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/NVIDIA-Kepler-GK110-GK210-Architecture-Whitepaper.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_5_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 4,
-            .fp32_tflops = 256,
-        },
-    .matrix_unit = {},
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// https://www.nvidia.com/content/PDF/product-specifications/GeForce_GTX_680_Whitepaper_FINAL.pdf
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_3_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 128,
-            .fp32_tflops = 384,
-        },
-    .matrix_unit = {},
-    .has_matrix_unit_sparsity_support = false,
-};
-
-const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
-    .vector_unit =
-        {
-            .fp64_tflops = 8,
-            .fp32_tflops = 64,
-        },
-    .matrix_unit = {},
-    .has_matrix_unit_sparsity_support = false,
-};
-
-// ROCm XLA collector emits rocprofiler-sdk's agent name, composed via
-// fmt::format("gfx{}{}{:x}", major, minor, step), e.g. "gfx942". 
-// See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp.
-// Reject a device name that does not follow this formatting.
-absl::string_view GfxVersionIfWellFormed(absl::string_view device_name) {
-  if (!absl::StartsWith(device_name, "gfx")) return "";
-  absl::string_view suffix = device_name.substr(3);
-  if (suffix.size() < 3) return "";
-  for (char c : suffix) {
-    if (!absl::ascii_isxdigit(c)) return "";
-  }
-  return device_name;
-}
-
-// Fallback for traces captured before the collector reported a device name.
-// Resolves only when the major, minor pair can identify a unique architecture.
-absl::string_view GfxVersionFromComputeCapability(int major, int minor) {
-  if (major == 9 && minor == 4) return "gfx942";  // CDNA 3, MI300 series
-  if (major == 9 && minor == 5) return "gfx950";  // CDNA 4, MI350 series
-  return "";
-}
-
-absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
-  absl::string_view gfx = GfxVersionIfWellFormed(device_cap.device_name());
-  if (!gfx.empty()) return gfx;
-  return GfxVersionFromComputeCapability(
-      device_cap.compute_capability().major(),
-      device_cap.compute_capability().minor());
-}
-
-// LDS bytes per CU per clock.
-// Each bank serves one read, write or atomic per cycle.
-//
-// AMD CDNA 4 architecture whitepaper, which additionally covers the LDS spec 
-// for earlier generations (CDNA 3 and prior):
-// https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
-//
-// RDNA series is absent as its LDS belongs to a workgroup processor rather than
-// a CU. The published per-cycle figure cannot clearly be attributed per CU.
-double GetAmdLdsBytesPerCuPerCycle(absl::string_view gfx_version) {
-  static const auto& kTable = *new absl::btree_map<absl::string_view, double>{
-      {"gfx908", 128.0},  // CDNA 1, 32 banks x 4 B
-      {"gfx90a", 128.0},  // CDNA 2, 32 banks x 4 B
-      {"gfx942", 128.0},  // CDNA 3, 32 banks x 4 B
-      {"gfx950", 256.0},  // CDNA 4, 64 banks x 4 B
-  };
-  auto it = kTable.find(gfx_version);
-  return it == kTable.end() ? 0.0 : it->second;
-}
-
-GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
-                                                   int minor_comp_cap) {
-  static const auto& kPerSMFlopCapsTable =
-      *new absl::btree_map<int, GpuFlopCapabilities const*>{
-          // TODO: Add newer GPUS when available.
-          {10000, &kComputeCap_PerSM_PerCycle_10_0},
-          {9000, &kComputeCap_PerSM_PerCycle_9_0},
-          {8090, &kComputeCap_PerSM_PerCycle_8_9},
-          {8060, &kComputeCap_PerSM_PerCycle_8_6},
-          {8000, &kComputeCap_PerSM_PerCycle_8_0},
-          {7050, &kComputeCap_PerSM_PerCycle_7_5},
-          {7000, &kComputeCap_PerSM_PerCycle_7_0},
-          {6010, &kComputeCap_PerSM_PerCycle_6_1},
-          {6000, &kComputeCap_PerSM_PerCycle_6_0},
-          {5000, &kComputeCap_PerSM_PerCycle_5_0},
-          {3000, &kComputeCap_PerSM_PerCycle_3_0},
-          {2000, &kComputeCap_PerSM_PerCycle_2_0},
-      };
-
-  // TODO(b/409612464): - Need more discussion on how to handle the case when
-  // the compute cap is not found in above table. Currently we back off to the
-  // highest compute cap less than the given compute cap, or the oldest compute
-  // cap in the table if the given compute cap is even older than it. Another
-  // way is to just report not found and return 0 in GpuFlopCapabilities. Also
-  // more fine-grained back off also could be used.
-  const int normalized_compute_cap =
-      major_comp_cap * 1000 + minor_comp_cap * 10;
-  auto it = kPerSMFlopCapsTable.lower_bound(normalized_compute_cap);
-  if (it == kPerSMFlopCapsTable.end() || it->first > normalized_compute_cap) {
-    if (it != kPerSMFlopCapsTable.begin()) it = std::prev(it);
-    LOG(WARNING) << "GPU compute capability " << major_comp_cap << "."
-                 << minor_comp_cap
-                 << " is not found. Use the highest compute cap known "
-                 << (it->first / 1000) << "." << ((it->first % 1000) / 10)
-                 << " instead.";
-  }
-  return GpuFlopCapabilities(*(it->second));
-}
-
-// FMA considered as 2 FLOPs.
-// Matrix rates are dense MFMA, vector rates are VALU.
-std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
-    absl::string_view gfx_version) {
-  static const auto& kTable =
-      *new absl::btree_map<absl::string_view, GpuFlopCapabilities>{
-          // MI100 (CDNA 1), 120 CU at 1.502 GHz: FP64 11.5, FP32 23.1,
-          // BF16 92.3, FP16 184.6 TFLOPS. bf16 MFMA is half rate on CDNA 1.
-          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html
-          {"gfx908",
-           {.vector_unit = {.fp64_tflops = 64, .fp32_tflops = 128},
-            .matrix_unit = {.bf16_tflops = 512, .fp16_tflops = 1024}}},
-          // MI250X (CDNA 2), 104 CU per GCD at 1.7 GHz: FP64 45.3, FP32 45.3,
-          // FP16 = BF16 362.1 TFLOPS per GCD. Full-rate FP64.
-          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html
-          {"gfx90a",
-           {.vector_unit = {.fp64_tflops = 256, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 2048, .fp16_tflops = 2048}}},
-          // MI300X (CDNA 3). CDNA 4 whitepaper Table 1, MI300X column.
-          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
-          {"gfx942",
-           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 2048,
-                            .fp16_tflops = 2048,
-                            .fp8_tflops = 4096}}},
-          // MI355X (CDNA 4). CDNA 4 whitepaper Table 1, MI355X column.
-          {"gfx950",
-           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 4096,
-                            .fp16_tflops = 4096,
-                            .fp8_tflops = 8192}}},
-      };
-  auto it = kTable.find(gfx_version);
-  if (it == kTable.end()) return std::nullopt;
-  return it->second;
-}
-
-GpuFlopCapabilities GetGpuFlopCapabilitiesPerCore(
-    const DeviceCapabilities& device_cap) {
-  GpuFlopCapabilities flops_cap{};
-  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
-    flops_cap =
-        GetNvidiaFlopCapsPerSMPerCycle(device_cap.compute_capability().major(),
-                                       device_cap.compute_capability().minor());
-  } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
-    absl::string_view gfx_version = ResolveAmdGfxVersion(device_cap);
-    if (std::optional<GpuFlopCapabilities> amd_flops =
-            GetAmdFlopCapsPerCuPerCycle(gfx_version)) {
-      flops_cap = *amd_flops;
-    } else {
-      LOG(WARNING) << "No FLOP rates known for AMD architecture '" << gfx_version
-                   << "'; peak compute will be reported as zero.";
-    }
-  } else {
-    LOG(WARNING) << "Unsupported device vendor " << device_cap.device_vendor();
-  }
-
-  flops_cap.ScaleWith(device_cap.clock_rate_in_ghz());
-  return flops_cap;
-}
-
-}  // namespace
 
 double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap) {
-  GpuFlopCapabilities core_flops = GetGpuFlopCapabilitiesPerCore(device_cap);
-  double result = std::max(
-      {core_flops.vector_unit.fp32_tflops, core_flops.vector_unit.fp16_tflops,
-       core_flops.matrix_unit.fp32_tflops, core_flops.matrix_unit.fp16_tflops});
-  VLOG(3) << "GetFlopMaxThroughputPerCore get result: " << result << " GFLOPs";
-  return result;
+  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
+    return cuda::GetFlopMaxThroughputPerCore(device_cap);
+  }
+  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    return rocm::GetFlopMaxThroughputPerCore(device_cap);
+  }
+  LOG(WARNING) << "Unsupported device vendor " << device_cap.device_vendor();
+  return 0.0;
 }
 
 double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap) {
-  double transaction_byts_per_cycle = 0.0;
   if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
-    // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm
-    // Compute capability 2.0, each bank has bandwidth of 4 bytes per 2 cycles.
-    // For compute capability 3.0 and above, each bank has bandwidth 8 bytes per
-    // cycle. Each SM has 32 banks.
-    transaction_byts_per_cycle =
-        device_cap.compute_capability().major() <= 2 ? (32 * 4 / 2) : (32 * 8);
-  } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
-    transaction_byts_per_cycle =
-        GetAmdLdsBytesPerCuPerCycle(ResolveAmdGfxVersion(device_cap));
+    return cuda::GetSharedMemoryBandwidthPerCore(device_cap);
   }
-  // Report zero for an unknown vendor or architecture.
-  if (transaction_byts_per_cycle <= 0.0) return 0.0;
-  double GiBPS = transaction_byts_per_cycle * device_cap.clock_rate_in_ghz();
-  return tsl::profiler::GigaToUni(GiBPS);
+  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    return rocm::GetSharedMemoryBandwidthPerCore(device_cap);
+  }
+  // Report zero rather than a value borrowed from another vendor.
+  return 0.0;
 }
 
 std::string GpuModelName(const DeviceCapabilities& device_cap) {
   if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
-    switch (device_cap.compute_capability().major()) {
-      case 2:
-        return "Nvidia GPU (Fermi)";
-      case 3:
-        return "Nvidia GPU (Kepler)";
-      case 5:
-        return "Nvidia GPU (Maxwell)";
-      case 6:
-        return "Nvidia GPU (Pascal)";
-      case 7:
-        if (device_cap.compute_capability().minor() < 5) {
-          return "Nvidia GPU (Volta)";
-        } else {
-          return "Nvidia GPU (Turing)";
-        }
-      case 8:
-        if (device_cap.compute_capability().minor() < 9) {
-          return "Nvidia GPU (Ampere)";
-        } else {
-          return "Nvidia GPU (Ada Lovelace)";
-        }
-      case 9:
-        return "Nvidia GPU (Hopper)";
-      case 10:
-        return "Nvidia GPU (Blackwell)";
-      default:
-        return "Nvidia GPU";
-    }
-  } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
-    // Attempt to resolve exact gfx architecture. If no resolution
-    // is reached, fall back to displaying the family (major) name.
-    absl::string_view gfx = ResolveAmdGfxVersion(device_cap);
-    if (!gfx.empty()) return absl::StrCat("AMD GPU - ", gfx);
-    switch (device_cap.compute_capability().major()) {
-      case 9:
-        return "AMD GPU - gfx-9XX series";
-      case 10:
-        return "AMD GPU - gfx-10XX series";
-      case 11:
-        return "AMD GPU - gfx-11XX series";
-      default:
-        return "AMD GPU";
-    }
-  } else {
-    LOG(ERROR) << "Unknown device vendor " << device_cap.device_vendor();
-    return "";
+    return cuda::GpuModelName(device_cap);
   }
+  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    return rocm::GpuModelName(device_cap);
+  }
+  LOG(ERROR) << "Unknown device vendor " << device_cap.device_vendor();
+  return "";
 }
 
 HardwareType ParseHardwareType(absl::string_view device_type) {

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
 #include <string>
 
 #include "absl/container/btree_map.h"
@@ -330,6 +331,49 @@ GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
   return GpuFlopCapabilities(*(it->second));
 }
 
+// Peak FLOPs per CU per cycle. FMA considered as 2 FLOPs. Matrix rates are dense
+// MFMA and vector rates are VALU. CDNA 3 and 4 are stated directly by the CDNA 4
+// whitepaper (Table 1, in these units); CDNA 1 and 2 are derived from the
+// published peak as: peak_flops / (cu_count * clock). Pinned by tests either way.
+//
+// fp16 is set alongside bf16 as GetFlopMaxThroughputPerSM considers only fp32
+// and fp16. A matrix rate left solely in bf16_tflops is skipped and the peak
+// falls back to vector fp32.
+std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
+    absl::string_view gfx_version) {
+  static const auto& kTable =
+      *new absl::btree_map<absl::string_view, GpuFlopCapabilities>{
+          // MI100 (CDNA 1), 120 CU at 1.502 GHz: FP64 11.5, FP32 23.1,
+          // BF16 92.3, FP16 184.6 TFLOPS. bf16 MFMA is half rate on CDNA 1.
+          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html
+          {"gfx908",
+           {.vector_unit = {.fp64_tflops = 64, .fp32_tflops = 128},
+            .matrix_unit = {.bf16_tflops = 512, .fp16_tflops = 1024}}},
+          // MI250X (CDNA 2), 104 CU per GCD at 1.7 GHz: FP64 45.3, FP32 45.3,
+          // FP16 = BF16 362.1 TFLOPS per GCD. Full-rate FP64.
+          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html
+          {"gfx90a",
+           {.vector_unit = {.fp64_tflops = 256, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 2048, .fp16_tflops = 2048}}},
+          // MI300X (CDNA 3). CDNA 4 whitepaper Table 1, MI300X column.
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+          {"gfx942",
+           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 2048,
+                            .fp16_tflops = 2048,
+                            .fp8_tflops = 4096}}},
+          // MI355X (CDNA 4). CDNA 4 whitepaper Table 1, MI355X column.
+          {"gfx950",
+           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 4096,
+                            .fp16_tflops = 4096,
+                            .fp8_tflops = 8192}}},
+      };
+  auto it = kTable.find(gfx_version);
+  if (it == kTable.end()) return std::nullopt;
+  return it->second;
+}
+
 GpuFlopCapabilities GetGpuFlopCapabilitiesPerSM(
     const DeviceCapabilities& device_cap) {
   GpuFlopCapabilities flops_cap{};
@@ -337,6 +381,15 @@ GpuFlopCapabilities GetGpuFlopCapabilitiesPerSM(
     flops_cap =
         GetNvidiaFlopCapsPerSMPerCycle(device_cap.compute_capability().major(),
                                        device_cap.compute_capability().minor());
+  } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    absl::string_view gfx_version = ResolveAmdGfxVersion(device_cap);
+    if (std::optional<GpuFlopCapabilities> amd_flops =
+            GetAmdFlopCapsPerCuPerCycle(gfx_version)) {
+      flops_cap = *amd_flops;
+    } else {
+      LOG(WARNING) << "No FLOP rates known for AMD architecture '" << gfx_version
+                   << "'; peak compute will be reported as zero.";
+    }
   } else {
     LOG(WARNING) << "Unsupported device vendor " << device_cap.device_vendor();
   }

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -39,7 +39,7 @@ namespace {
 // https://resources.nvidia.com/en-us-blackwell-architecture?ncid=pa-srch-goog-585983-Intel-Brand-Broad
 // Dense Compute as default.
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_10_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 148,
             .fp32_tflops = 296,
@@ -47,7 +47,7 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_10_0 = {
             .fp16_tflops = 592,
             .int8_tops = 1184,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp64_tflops = 148,
             .fp32_tflops = 4096,
@@ -56,12 +56,12 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_10_0 = {
             .fp8_tflops = 16384,
             .int8_tops = 16384,
         },
-    .has_tensor_core_sparsity_support = true,
+    .has_matrix_unit_sparsity_support = true,
 };
 
 // https://resources.nvidia.com/en-us-tensor-core/gtc22-whitepaper-hopper
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_9_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 128,
             .fp32_tflops = 256,
@@ -69,7 +69,7 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_9_0 = {
             .fp16_tflops = 512,
             .int8_tops = 1024,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp64_tflops = 256,
             .fp32_tflops = 2048,
@@ -78,12 +78,12 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_9_0 = {
             .fp8_tflops = 8192,
             .int8_tops = 8192,
         },
-    .has_tensor_core_sparsity_support = true,
+    .has_matrix_unit_sparsity_support = true,
 };
 
 // https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_9 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 128,
             .fp32_tflops = 256,
@@ -91,7 +91,7 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_9 = {
             .fp16_tflops = 256,
             .int8_tops = 512,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp32_tflops = 512,
             .bf16_tflops = 1024,
@@ -100,12 +100,12 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_9 = {
             .int8_tops = 2048,
             .int4_tops = 4096,
         },
-    .has_tensor_core_sparsity_support = true,
+    .has_matrix_unit_sparsity_support = true,
 };
 
 // https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_6 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 128,
             .fp32_tflops = 256,
@@ -113,7 +113,7 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_6 = {
             .fp16_tflops = 256,
             .int8_tops = 512,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp32_tflops = 256,
             .bf16_tflops = 512,
@@ -121,12 +121,12 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_6 = {
             .int8_tops = 2048,
             .int4_tops = 4096,
         },
-    .has_tensor_core_sparsity_support = true,
+    .has_matrix_unit_sparsity_support = true,
 };
 
 // https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 64,
             .fp32_tflops = 128,
@@ -134,7 +134,7 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_0 = {
             .fp16_tflops = 512,
             .int8_tops = 512,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp64_tflops = 128,
             .fp32_tflops = 1024,
@@ -142,30 +142,30 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_8_0 = {
             .fp16_tflops = 2048,
             .int8_tops = 4096,
         },
-    .has_tensor_core_sparsity_support = true,
+    .has_matrix_unit_sparsity_support = true,
 };
 
 // https://images.nvidia.com/aem-dam/en-zz/Solutions/design-visualization/technologies/turing-architecture/NVIDIA-Turing-Architecture-Whitepaper.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_5 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 64,
             .fp32_tflops = 128,
             .fp16_tflops = 256,
             .int8_tops = 512,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp16_tflops = 1024,
             .int8_tops = 2048,
             .int4_tops = 4096,
         },
-    .has_tensor_core_sparsity_support = false,
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 64,
             .fp32_tflops = 128,
@@ -173,69 +173,69 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_7_0 = {
             .fp16_tflops = 256,
             .int8_tops = 512,
         },
-    .tensor_core =
+    .matrix_unit =
         {
             .fp16_tflops = 1024,
         },
-    .has_tensor_core_sparsity_support = false,
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_1 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 8,
             .fp32_tflops = 256,
             .fp16_tflops = 4,
             .int8_tops = 1024,
         },
-    .tensor_core = {},
-    .has_tensor_core_sparsity_support = false,
+    .matrix_unit = {},
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_6_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 64,
             .fp32_tflops = 128,
             .fp16_tflops = 256,
             .int8_tops = 512,
         },
-    .tensor_core = {},
-    .has_tensor_core_sparsity_support = false,
+    .matrix_unit = {},
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-product-literature/NVIDIA-Kepler-GK110-GK210-Architecture-Whitepaper.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_5_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 4,
             .fp32_tflops = 256,
         },
-    .tensor_core = {},
-    .has_tensor_core_sparsity_support = false,
+    .matrix_unit = {},
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // https://www.nvidia.com/content/PDF/product-specifications/GeForce_GTX_680_Whitepaper_FINAL.pdf
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_3_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 128,
             .fp32_tflops = 384,
         },
-    .tensor_core = {},
-    .has_tensor_core_sparsity_support = false,
+    .matrix_unit = {},
+    .has_matrix_unit_sparsity_support = false,
 };
 
 const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
-    .cuda_core =
+    .vector_unit =
         {
             .fp64_tflops = 8,
             .fp32_tflops = 64,
         },
-    .tensor_core = {},
-    .has_tensor_core_sparsity_support = false,
+    .matrix_unit = {},
+    .has_matrix_unit_sparsity_support = false,
 };
 
 // Extracts the AMD architecture from a reported device name.
@@ -350,8 +350,8 @@ GpuFlopCapabilities GetGpuFlopCapabilitiesPerSM(
 double GetFlopMaxThroughputPerSM(const DeviceCapabilities& device_cap) {
   GpuFlopCapabilities sm_flops = GetGpuFlopCapabilitiesPerSM(device_cap);
   double result = std::max(
-      {sm_flops.cuda_core.fp32_tflops, sm_flops.cuda_core.fp16_tflops,
-       sm_flops.tensor_core.fp32_tflops, sm_flops.tensor_core.fp16_tflops});
+      {sm_flops.vector_unit.fp32_tflops, sm_flops.vector_unit.fp16_tflops,
+       sm_flops.matrix_unit.fp32_tflops, sm_flops.matrix_unit.fp16_tflops});
   VLOG(3) << "GetFlopMaxThroughputPerSM get result: " << result << " GFLOPs";
   return result;
 }

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -317,6 +317,14 @@ double GetFlopMaxThroughputPerSM(const DeviceCapabilities& device_cap) {
 }
 
 double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap) {
+  if (device_cap.device_vendor() != tsl::profiler::kDeviceVendorNvidia) {
+    // The bank geometry below is Nvidia's, and it is keyed on a compute
+    // capability that other vendors do not use the same way. Applying it
+    // regardless produces a plausible but wrong number, which is worse than
+    // reporting none: a missing roofline band reads as unknown, while a wrong
+    // one reads as authoritative.
+    return 0.0;
+  }
   // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm
   // Compute capability 2.0, each bank has bandwidth of 4 bytes per 2 cycles.
   // For compute capability 3.0 and above, each bank has bandwidth 8 bytes per

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -251,6 +251,46 @@ absl::string_view GfxVersionFromDeviceName(absl::string_view device_name) {
   return device_name.substr(0, device_name.find(':'));
 }
 
+// Fallback for traces captured before the collector reported a device name.
+// Only pairs identifying exactly one architecture are listed: ROCm derives the
+// capability from gfx_target_version and drops the step digit, so (9, 0) covers
+// both gfx908 (MI100) and gfx90a (MI200/250), whose rates differ.
+absl::string_view GfxVersionFromComputeCapability(int major, int minor) {
+  if (major == 9 && minor == 4) return "gfx942";  // CDNA 3, MI300 series
+  if (major == 9 && minor == 5) return "gfx950";  // CDNA 4, MI350 series
+  return "";
+}
+
+// Resolves the architecture used to key the AMD tables below: the reported
+// device name if there is one, else the compute capability.
+absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
+  absl::string_view gfx = GfxVersionFromDeviceName(device_cap.device_name());
+  if (!gfx.empty()) return gfx;
+  return GfxVersionFromComputeCapability(
+      device_cap.compute_capability().major(),
+      device_cap.compute_capability().minor());
+}
+
+// LDS bytes per CU per clock. Each bank serves one read, write or atomic per
+// cycle, so the figure is the same in both directions.
+//
+// AMD CDNA 4 architecture whitepaper, which additionally covers LDS spec for
+// earlier generations (CDNA 3 and prior):
+// https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+//
+// Note RDNA series is absent as its LDS belongs to a workgroup processor rather
+// than a CU. The published per-cycle figure cannot clearly be attributed per CU.
+double GetAmdLdsBytesPerCuPerCycle(absl::string_view gfx_version) {
+  static const auto& kTable = *new absl::btree_map<absl::string_view, double>{
+      {"gfx908", 128.0},  // CDNA 1, 32 banks x 4 B
+      {"gfx90a", 128.0},  // CDNA 2, 32 banks x 4 B
+      {"gfx942", 128.0},  // CDNA 3, 32 banks x 4 B
+      {"gfx950", 256.0},  // CDNA 4, 64 banks x 4 B
+  };
+  auto it = kTable.find(gfx_version);
+  return it == kTable.end() ? 0.0 : it->second;
+}
+
 GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
                                                    int minor_comp_cap) {
   static const auto& kPerSMFlopCapsTable =
@@ -317,20 +357,21 @@ double GetFlopMaxThroughputPerSM(const DeviceCapabilities& device_cap) {
 }
 
 double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap) {
-  if (device_cap.device_vendor() != tsl::profiler::kDeviceVendorNvidia) {
-    // The bank geometry below is Nvidia's, and it is keyed on a compute
-    // capability that other vendors do not use the same way. Applying it
-    // regardless produces a plausible but wrong number, which is worse than
-    // reporting none: a missing roofline band reads as unknown, while a wrong
-    // one reads as authoritative.
-    return 0.0;
+  double transaction_byts_per_cycle = 0.0;
+  if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
+    // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm
+    // Compute capability 2.0, each bank has bandwidth of 4 bytes per 2 cycles.
+    // For compute capability 3.0 and above, each bank has bandwidth 8 bytes per
+    // cycle. Each SM has 32 banks.
+    transaction_byts_per_cycle =
+        device_cap.compute_capability().major() <= 2 ? (32 * 4 / 2) : (32 * 8);
+  } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
+    transaction_byts_per_cycle =
+        GetAmdLdsBytesPerCuPerCycle(ResolveAmdGfxVersion(device_cap));
   }
-  // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm
-  // Compute capability 2.0, each bank has bandwidth of 4 bytes per 2 cycles.
-  // For compute capability 3.0 and above, each bank has bandwidth 8 bytes per
-  // cycle. Each SM has 32 banks.
-  double transaction_byts_per_cycle =
-      device_cap.compute_capability().major() <= 2 ? (32 * 4 / 2) : (32 * 8);
+  // An unknown vendor or architecture reports nothing rather than a value
+  // borrowed from hardware it does not describe.
+  if (transaction_byts_per_cycle <= 0.0) return 0.0;
   double GiBPS = transaction_byts_per_cycle * device_cap.clock_rate_in_ghz();
   return tsl::profiler::GigaToUni(GiBPS);
 }

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -366,7 +366,7 @@ std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
   return it->second;
 }
 
-GpuFlopCapabilities GetGpuFlopCapabilitiesPerSM(
+GpuFlopCapabilities GetGpuFlopCapabilitiesPerCore(
     const DeviceCapabilities& device_cap) {
   GpuFlopCapabilities flops_cap{};
   if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
@@ -392,16 +392,16 @@ GpuFlopCapabilities GetGpuFlopCapabilitiesPerSM(
 
 }  // namespace
 
-double GetFlopMaxThroughputPerSM(const DeviceCapabilities& device_cap) {
-  GpuFlopCapabilities sm_flops = GetGpuFlopCapabilitiesPerSM(device_cap);
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap) {
+  GpuFlopCapabilities core_flops = GetGpuFlopCapabilitiesPerCore(device_cap);
   double result = std::max(
-      {sm_flops.vector_unit.fp32_tflops, sm_flops.vector_unit.fp16_tflops,
-       sm_flops.matrix_unit.fp32_tflops, sm_flops.matrix_unit.fp16_tflops});
-  VLOG(3) << "GetFlopMaxThroughputPerSM get result: " << result << " GFLOPs";
+      {core_flops.vector_unit.fp32_tflops, core_flops.vector_unit.fp16_tflops,
+       core_flops.matrix_unit.fp32_tflops, core_flops.matrix_unit.fp16_tflops});
+  VLOG(3) << "GetFlopMaxThroughputPerCore get result: " << result << " GFLOPs";
   return result;
 }
 
-double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap) {
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap) {
   double transaction_byts_per_cycle = 0.0;
   if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorNvidia) {
     // https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/memorystatisticsshared.htm

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -239,31 +239,21 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
     .has_matrix_unit_sparsity_support = false,
 };
 
-// Extracts the AMD architecture from a reported device name.
-//
-// ROCm collector emits rocprofiler-sdk's agent name, composed via
-// fmt::format("gfx{}{}{:x}", major, minor, step), so it is a bare processor name
-// such as "gfx942". See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp:
-// https://github.com/ROCm/rocprofiler-sdk/blob/amd-staging/source/lib/rocprofiler-sdk/agent.cpp#L769-L775
-//
-// HIP's hipDeviceProp_t::gcnArchName instead carries the target-ID form,
-// "gfx942:sramecc+:xnack-", so keep only the processor.
+// ROCm XLA collector emits rocprofiler-sdk's agent name, composed via
+// fmt::format("gfx{}{}{:x}", major, minor, step), e.g. "gfx942".
+// See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp.
 absl::string_view GfxVersionFromDeviceName(absl::string_view device_name) {
   return device_name.substr(0, device_name.find(':'));
 }
 
 // Fallback for traces captured before the collector reported a device name.
-// Only pairs identifying exactly one architecture are listed: ROCm derives the
-// capability from gfx_target_version and drops the step digit, so (9, 0) covers
-// both gfx908 (MI100) and gfx90a (MI200/250), whose rates differ.
+// Resolves only when the major, minor pair can identify a unique architecture.
 absl::string_view GfxVersionFromComputeCapability(int major, int minor) {
   if (major == 9 && minor == 4) return "gfx942";  // CDNA 3, MI300 series
   if (major == 9 && minor == 5) return "gfx950";  // CDNA 4, MI350 series
   return "";
 }
 
-// Resolves the architecture used to key the AMD tables below: the reported
-// device name if there is one, else the compute capability.
 absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
   absl::string_view gfx = GfxVersionFromDeviceName(device_cap.device_name());
   if (!gfx.empty()) return gfx;
@@ -272,15 +262,15 @@ absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
       device_cap.compute_capability().minor());
 }
 
-// LDS bytes per CU per clock. Each bank serves one read, write or atomic per
-// cycle, so the figure is the same in both directions.
+// LDS bytes per CU per clock.
+// Each bank serves one read, write or atomic per cycle.
 //
-// AMD CDNA 4 architecture whitepaper, which additionally covers LDS spec for
-// earlier generations (CDNA 3 and prior):
+// AMD CDNA 4 architecture whitepaper, which additionally covers the LDS spec 
+// for earlier generations (CDNA 3 and prior):
 // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
 //
-// Note RDNA series is absent as its LDS belongs to a workgroup processor rather
-// than a CU. The published per-cycle figure cannot clearly be attributed per CU.
+// RDNA series is absent as its LDS belongs to a workgroup processor rather than
+// a CU. The published per-cycle figure cannot clearly be attributed per CU.
 double GetAmdLdsBytesPerCuPerCycle(absl::string_view gfx_version) {
   static const auto& kTable = *new absl::btree_map<absl::string_view, double>{
       {"gfx908", 128.0},  // CDNA 1, 32 banks x 4 B
@@ -331,14 +321,8 @@ GpuFlopCapabilities GetNvidiaFlopCapsPerSMPerCycle(int major_comp_cap,
   return GpuFlopCapabilities(*(it->second));
 }
 
-// Peak FLOPs per CU per cycle. FMA considered as 2 FLOPs. Matrix rates are dense
-// MFMA and vector rates are VALU. CDNA 3 and 4 are stated directly by the CDNA 4
-// whitepaper (Table 1, in these units); CDNA 1 and 2 are derived from the
-// published peak as: peak_flops / (cu_count * clock). Pinned by tests either way.
-//
-// fp16 is set alongside bf16 as GetFlopMaxThroughputPerSM considers only fp32
-// and fp16. A matrix rate left solely in bf16_tflops is skipped and the peak
-// falls back to vector fp32.
+// FMA considered as 2 FLOPs.
+// Matrix rates are dense MFMA, vector rates are VALU.
 std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
     absl::string_view gfx_version) {
   static const auto& kTable =
@@ -422,8 +406,7 @@ double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap) {
     transaction_byts_per_cycle =
         GetAmdLdsBytesPerCuPerCycle(ResolveAmdGfxVersion(device_cap));
   }
-  // An unknown vendor or architecture reports nothing rather than a value
-  // borrowed from hardware it does not describe.
+  // Report zero for an unknown vendor or architecture.
   if (transaction_byts_per_cycle <= 0.0) return 0.0;
   double GiBPS = transaction_byts_per_cycle * device_cap.clock_rate_in_ghz();
   return tsl::profiler::GigaToUni(GiBPS);
@@ -460,9 +443,8 @@ std::string GpuModelName(const DeviceCapabilities& device_cap) {
         return "Nvidia GPU";
     }
   } else if (device_cap.device_vendor() == tsl::profiler::kDeviceVendorAMD) {
-    // Resolved as the roofline tables do, so the reported architecture and the
-    // rates keyed on it never disagree. Falls back to the family below when
-    // neither the device name nor the compute capability identifies one.
+    // Attempt to resolve exact gfx architecture. If no resolution
+    // is reached, fall back to displaying the family (major) name.
     absl::string_view gfx = ResolveAmdGfxVersion(device_cap);
     if (!gfx.empty()) return absl::StrCat("AMD GPU - ", gfx);
     switch (device_cap.compute_capability().major()) {

--- a/xprof/utils/hardware_type_utils.cc
+++ b/xprof/utils/hardware_type_utils.cc
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "absl/container/btree_map.h"
 #include "absl/log/log.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -240,10 +241,17 @@ const GpuFlopCapabilities kComputeCap_PerSM_PerCycle_2_0 = {
 };
 
 // ROCm XLA collector emits rocprofiler-sdk's agent name, composed via
-// fmt::format("gfx{}{}{:x}", major, minor, step), e.g. "gfx942".
+// fmt::format("gfx{}{}{:x}", major, minor, step), e.g. "gfx942". 
 // See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp.
-absl::string_view GfxVersionFromDeviceName(absl::string_view device_name) {
-  return device_name.substr(0, device_name.find(':'));
+// Reject a device name that does not follow this formatting.
+absl::string_view GfxVersionIfWellFormed(absl::string_view device_name) {
+  if (!absl::StartsWith(device_name, "gfx")) return "";
+  absl::string_view suffix = device_name.substr(3);
+  if (suffix.size() < 3) return "";
+  for (char c : suffix) {
+    if (!absl::ascii_isxdigit(c)) return "";
+  }
+  return device_name;
 }
 
 // Fallback for traces captured before the collector reported a device name.
@@ -255,7 +263,7 @@ absl::string_view GfxVersionFromComputeCapability(int major, int minor) {
 }
 
 absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
-  absl::string_view gfx = GfxVersionFromDeviceName(device_cap.device_name());
+  absl::string_view gfx = GfxVersionIfWellFormed(device_cap.device_name());
   if (!gfx.empty()) return gfx;
   return GfxVersionFromComputeCapability(
       device_cap.compute_capability().major(),

--- a/xprof/utils/hardware_type_utils.h
+++ b/xprof/utils/hardware_type_utils.h
@@ -59,14 +59,13 @@ struct GpuFlopCapabilities {
   }
 };
 
-// Get peak single precision throughput of the GPU in GFLOPS per
-// streaming multiprocessor.
+// Get peak single precision throughput of the GPU in GFLOPS per core (SM, CU)
 // TODO: Need design on how to use the sparsity capability of FLOPs.
-double GetFlopMaxThroughputPerSM(const DeviceCapabilities& device_cap);
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap);
 
-// for Nvidia GPU, return shared memory bandwidth in Bytes Per Second on
-// one single SM given the GPU core freq in device_cap.
-double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap);
+// Return shared memory bandwidth (or LDS) in Bytes Per Second on one single core
+// given the GPU core freq in device_cap.
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap);
 
 // Returns the GPU model name from the given DeviceCapabilities.
 // For nvidia GPUs, the name is like "Nvidia GPU (Kepler)" or "Nvidia GPU

--- a/xprof/utils/hardware_type_utils.h
+++ b/xprof/utils/hardware_type_utils.h
@@ -47,13 +47,15 @@ struct GpuFlopCapabilities {
     }
   };
 
-  FlopCapabilityOnPrecisions cuda_core;
-  FlopCapabilityOnPrecisions tensor_core;
-  bool has_tensor_core_sparsity_support = false;
+  // Vector unit: NVIDIA = Cuda Cores, AMD = vector ALUs
+  FlopCapabilityOnPrecisions vector_unit;
+  // Matrix unit: NVIDIA = Tensor Cores, AMD = Matrix Cores (MFMA)
+  FlopCapabilityOnPrecisions matrix_unit;
+  bool has_matrix_unit_sparsity_support = false;
 
   void ScaleWith(double scale) {
-    cuda_core.ScaleWith(scale);
-    tensor_core.ScaleWith(scale);
+    vector_unit.ScaleWith(scale);
+    matrix_unit.ScaleWith(scale);
   }
 };
 

--- a/xprof/utils/hardware_type_utils.h
+++ b/xprof/utils/hardware_type_utils.h
@@ -24,40 +24,7 @@ limitations under the License.
 namespace tensorflow {
 namespace profiler {
 
-struct GpuFlopCapabilities {
-  struct FlopCapabilityOnPrecisions {
-    double fp64_tflops = 0;
-    double fp32_tflops = 0;  // also for tf32 for nvidia tensor core
-    double bf16_tflops = 0;
-    double fp16_tflops = 0;
-    double fp8_tflops = 0;
-    double int8_tops = 0;
-    double fp4_tflops = 0;
-    double int4_tops = 0;
-
-    void ScaleWith(double scale) {
-      fp64_tflops *= scale;
-      fp32_tflops *= scale;
-      bf16_tflops *= scale;
-      fp16_tflops *= scale;
-      fp8_tflops *= scale;
-      int8_tops *= scale;
-      fp4_tflops *= scale;
-      int4_tops *= scale;
-    }
-  };
-
-  // Vector unit: NVIDIA = Cuda Cores, AMD = vector ALUs
-  FlopCapabilityOnPrecisions vector_unit;
-  // Matrix unit: NVIDIA = Tensor Cores, AMD = Matrix Cores (MFMA)
-  FlopCapabilityOnPrecisions matrix_unit;
-  bool has_matrix_unit_sparsity_support = false;
-
-  void ScaleWith(double scale) {
-    vector_unit.ScaleWith(scale);
-    matrix_unit.ScaleWith(scale);
-  }
-};
+// Dispatches to the vendor model in cuda_type_utils.h or rocm_type_utils.h.
 
 // Get peak single precision throughput of the GPU in GFLOPS per core (SM, CU)
 // TODO: Need design on how to use the sparsity capability of FLOPs.

--- a/xprof/utils/hardware_type_utils.h
+++ b/xprof/utils/hardware_type_utils.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef XPROF_UTILS_HARDWARE_TYPE_UTILS_H_
 #define XPROF_UTILS_HARDWARE_TYPE_UTILS_H_
 
+#include <string>
+
 #include "absl/strings/string_view.h"
 #include "plugin/xprof/protobuf/hardware_types.pb.h"
 
@@ -66,10 +68,11 @@ double GetSharedMemoryBandwidthPerSM(const DeviceCapabilities& device_cap);
 
 // Returns the GPU model name from the given DeviceCapabilities.
 // For nvidia GPUs, the name is like "Nvidia GPU (Kepler)" or "Nvidia GPU
-// (Turing)". For AMD GPUs, the name is like "AMD GPU - gfx-10XX series".
+// (Turing)". For AMD GPUs, the name is like "AMD GPU - gfx942", falling back to
+// "AMD GPU - gfx-10XX series" when the architecture was not reported.
 // The model name here for Nvidia GPU in fact refers to its microarchitecture
 // name.
-absl::string_view GpuModelName(const DeviceCapabilities& device_cap);
+std::string GpuModelName(const DeviceCapabilities& device_cap);
 
 HardwareType ParseHardwareType(absl::string_view device_type);
 

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -101,6 +101,74 @@ TEST(HardwareTypeUtilsTest, A100PeakComputTFlops) {
   EXPECT_NEAR(peak_tflops, 312, /*abs_error=*/1.0);
 }
 
+TEST(HardwareTypeUtilsTest, Mi300XPeakComputeTFlops) {
+  DeviceCapabilities device_cap;
+  // MI300X: 304 CU at 2.1 GHz, published dense FP16/BF16 matrix 1307.4 TFLOPS.
+  device_cap.set_clock_rate_in_ghz(2.1);
+  device_cap.set_num_cores(304);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx942:sramecc+:xnack-");
+
+  double peak_tflops =
+      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+  // Guards the bf16 trap: if the matrix rate were stored only in bf16_tflops,
+  // the max would skip it and report the vector fp32 peak of 163.4 instead.
+  EXPECT_NEAR(peak_tflops, 1307.4, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, Mi100PeakComputeTFlops) {
+  DeviceCapabilities device_cap;
+  // MI100: 120 CU at 1.502 GHz, published FP16 matrix 184.6 TFLOPS. CDNA 1 is
+  // the one architecture where bf16 MFMA is half rate, so fp16 is the headline.
+  device_cap.set_clock_rate_in_ghz(1.502);
+  device_cap.set_num_cores(120);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx908");
+
+  double peak_tflops =
+      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+  EXPECT_NEAR(peak_tflops, 184.6, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, Mi250XPeakComputeTFlopsPerGcd) {
+  DeviceCapabilities device_cap;
+  // MI250X: 104 CU per GCD at 1.7 GHz, published FP16/BF16 362.1 TFLOPS per GCD.
+  device_cap.set_clock_rate_in_ghz(1.7);
+  device_cap.set_num_cores(104);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx90a");
+
+  double peak_tflops =
+      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+  EXPECT_NEAR(peak_tflops, 362.1, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, Mi355XPeakComputeTFlops) {
+  DeviceCapabilities device_cap;
+  // MI355X: 256 CU at 2.4 GHz, published dense FP16/BF16 matrix 2.5 PFLOPS.
+  device_cap.set_clock_rate_in_ghz(2.4);
+  device_cap.set_num_cores(256);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx950");
+
+  double peak_tflops =
+      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+  EXPECT_NEAR(peak_tflops, 2516.6, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, AmbiguousAmdComputeCapabilityReportsNoPeak) {
+  // (9, 0) is gfx908 or gfx90a, whose rates differ by 2x. Without a device name
+  // to disambiguate, report nothing rather than pick one.
+  DeviceCapabilities device_cap;
+  device_cap.set_clock_rate_in_ghz(1.7);
+  device_cap.set_num_cores(104);
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+  device_cap.mutable_compute_capability()->set_minor(0);
+
+  EXPECT_EQ(GetFlopMaxThroughputPerSM(device_cap), 0.0);
+}
+
 TEST(HardwareTypeUtilsTest, Mi300XSharedMemoryBandwidth) {
   DeviceCapabilities device_cap;
   // MI300X: 304 CU at 2.1 GHz, CDNA 3 (32 LDS banks x 4 B = 128 B/clock/CU).

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -107,7 +107,7 @@ TEST(HardwareTypeUtilsTest, Mi300XPeakComputeTFlops) {
   device_cap.set_clock_rate_in_ghz(2.1);
   device_cap.set_num_cores(304);
   device_cap.set_device_vendor("AMD");
-  device_cap.set_device_name("gfx942:sramecc+:xnack-");
+  device_cap.set_device_name("gfx942");
 
   double peak_tflops =
       GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
@@ -249,17 +249,24 @@ TEST(HardwareTypeUtilsTest, GpuModelNameFallsBackToFamilyWithoutName) {
   EXPECT_EQ(GpuModelName(device_cap), "Nvidia GPU (Hopper)");
 }
 
-TEST(HardwareTypeUtilsTest, GpuModelNameReportsAmdArchAndStripsFeatures) {
+TEST(HardwareTypeUtilsTest, GpuModelNameReportsAmdArchFromDeviceName) {
   DeviceCapabilities device_cap;
   device_cap.set_device_vendor("AMD");
-  device_cap.mutable_compute_capability()->set_major(9);
-  device_cap.mutable_compute_capability()->set_minor(4);
-  device_cap.set_device_name("gfx942:sramecc+:xnack-");
+  device_cap.set_device_name("gfx950");
 
   // Must remain more specific than the family fallback, and must still contain
   // "GPU" because ParseHardwareType and the frontend both key on that.
-  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx942");
+  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx950");
   EXPECT_EQ(ParseHardwareType(GpuModelName(device_cap)), HardwareType::GPU);
+}
+
+TEST(HardwareTypeUtilsTest, GpuModelNameRejectsMalformedAmdDeviceName) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("AMD");
+  // Target-ID form, which the collector does not emit.
+  device_cap.set_device_name("gfx942:sramecc+:xnack-");
+
+  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU");
 }
 
 TEST(HardwareTypeUtilsTest, GpuModelNameResolvesAmdArchFromComputeCapability) {

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -38,7 +38,7 @@ TEST(HardwareTypeUtilsTest, B200PeakComputTFlops) {
 
   // Get target TFLOPS per SM and check.
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 2218, /*abs_error=*/1.0);
 }
 
@@ -58,7 +58,7 @@ TEST(HardwareTypeUtilsTest, FutureBlackwellPeakComputTFlops) {
 
   // Get target TFLOPS per SM and check.
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 2218, /*abs_error=*/1.0);
 }
 
@@ -78,7 +78,7 @@ TEST(HardwareTypeUtilsTest, H100PeakComputTFlops) {
 
   // Get target TFLOPS per SM and check.
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 756, /*abs_error=*/1.0);
 }
 
@@ -97,7 +97,7 @@ TEST(HardwareTypeUtilsTest, A100PeakComputTFlops) {
   device_cap.mutable_compute_capability()->set_minor(0);
 
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 312, /*abs_error=*/1.0);
 }
 
@@ -110,7 +110,7 @@ TEST(HardwareTypeUtilsTest, Mi300XPeakComputeTFlops) {
   device_cap.set_device_name("gfx942");
 
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   // Guards the bf16 trap: if the matrix rate were stored only in bf16_tflops,
   // the max would skip it and report the vector fp32 peak of 163.4 instead.
   EXPECT_NEAR(peak_tflops, 1307.4, /*abs_error=*/1.0);
@@ -126,7 +126,7 @@ TEST(HardwareTypeUtilsTest, Mi100PeakComputeTFlops) {
   device_cap.set_device_name("gfx908");
 
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 184.6, /*abs_error=*/1.0);
 }
 
@@ -139,7 +139,7 @@ TEST(HardwareTypeUtilsTest, Mi250XPeakComputeTFlopsPerGcd) {
   device_cap.set_device_name("gfx90a");
 
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 362.1, /*abs_error=*/1.0);
 }
 
@@ -152,7 +152,7 @@ TEST(HardwareTypeUtilsTest, Mi355XPeakComputeTFlops) {
   device_cap.set_device_name("gfx950");
 
   double peak_tflops =
-      GetFlopMaxThroughputPerSM(device_cap) * device_cap.num_cores() / 1000.0;
+      GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
   EXPECT_NEAR(peak_tflops, 2516.6, /*abs_error=*/1.0);
 }
 
@@ -166,7 +166,7 @@ TEST(HardwareTypeUtilsTest, AmbiguousAmdComputeCapabilityReportsNoPeak) {
   device_cap.mutable_compute_capability()->set_major(9);
   device_cap.mutable_compute_capability()->set_minor(0);
 
-  EXPECT_EQ(GetFlopMaxThroughputPerSM(device_cap), 0.0);
+  EXPECT_EQ(GetFlopMaxThroughputPerCore(device_cap), 0.0);
 }
 
 TEST(HardwareTypeUtilsTest, Mi300XSharedMemoryBandwidth) {
@@ -179,7 +179,7 @@ TEST(HardwareTypeUtilsTest, Mi300XSharedMemoryBandwidth) {
 
   double aggregate_giga_bytes_per_second =
       device_cap.num_cores() *
-      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerCore(device_cap));
   // 304 * 128 B * 2.1e9 = 81,715.2 GB/s. Notably half of what the Nvidia bank
   // model would report, since CDNA has the same 32 banks at half the width.
   EXPECT_NEAR(aggregate_giga_bytes_per_second, 81715.2, /*abs_error=*/1.0);
@@ -195,7 +195,7 @@ TEST(HardwareTypeUtilsTest, Mi355XSharedMemoryBandwidthDoubles) {
 
   double aggregate_giga_bytes_per_second =
       device_cap.num_cores() *
-      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerCore(device_cap));
   EXPECT_NEAR(aggregate_giga_bytes_per_second, 157286.4, /*abs_error=*/1.0);
 }
 
@@ -211,7 +211,7 @@ TEST(HardwareTypeUtilsTest, SharedMemoryBandwidthFromComputeCapability) {
 
   double aggregate_giga_bytes_per_second =
       device_cap.num_cores() *
-      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerCore(device_cap));
   EXPECT_NEAR(aggregate_giga_bytes_per_second, 81715.2, /*abs_error=*/1.0);
 }
 
@@ -225,7 +225,7 @@ TEST(HardwareTypeUtilsTest, SharedMemoryBandwidthUnknownAmdArchReportsNothing) {
   device_cap.mutable_compute_capability()->set_major(9);
   device_cap.mutable_compute_capability()->set_minor(0);
 
-  EXPECT_EQ(GetSharedMemoryBandwidthPerSM(device_cap), 0.0);
+  EXPECT_EQ(GetSharedMemoryBandwidthPerCore(device_cap), 0.0);
 }
 
 TEST(HardwareTypeUtilsTest, GpuModelNameIgnoresNvidiaProductName) {

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -101,6 +101,48 @@ TEST(HardwareTypeUtilsTest, A100PeakComputTFlops) {
   EXPECT_NEAR(peak_tflops, 312, /*abs_error=*/1.0);
 }
 
+TEST(HardwareTypeUtilsTest, GpuModelNameIgnoresNvidiaProductName) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("Nvidia");
+  device_cap.mutable_compute_capability()->set_major(9);
+  // CUPTI reports a product name, which contains no "GPU" substring. Returning
+  // it would make ParseHardwareType, the GPU roofline table selection and the
+  // frontend all stop recognising the device.
+  device_cap.set_device_name("NVIDIA H100 80GB HBM3");
+
+  EXPECT_EQ(GpuModelName(device_cap), "Nvidia GPU (Hopper)");
+  EXPECT_EQ(ParseHardwareType(GpuModelName(device_cap)), HardwareType::GPU);
+}
+
+TEST(HardwareTypeUtilsTest, GpuModelNameFallsBackToFamilyWithoutName) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("Nvidia");
+  device_cap.mutable_compute_capability()->set_major(9);
+
+  EXPECT_EQ(GpuModelName(device_cap), "Nvidia GPU (Hopper)");
+}
+
+TEST(HardwareTypeUtilsTest, GpuModelNameReportsAmdArchAndStripsFeatures) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+  device_cap.mutable_compute_capability()->set_minor(4);
+  device_cap.set_device_name("gfx942:sramecc+:xnack-");
+
+  // Must remain more specific than the family fallback, and must still contain
+  // "GPU" because ParseHardwareType and the frontend both key on that.
+  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx942");
+  EXPECT_EQ(ParseHardwareType(GpuModelName(device_cap)), HardwareType::GPU);
+}
+
+TEST(HardwareTypeUtilsTest, GpuModelNameFallsBackToAmdFamilyWithoutName) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+
+  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx-9XX series");
+}
+
 }  // namespace
 }  // namespace profiler
 }  // namespace tensorflow

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -130,9 +130,10 @@ TEST(HardwareTypeUtilsTest, Mi100PeakComputeTFlops) {
   EXPECT_NEAR(peak_tflops, 184.6, /*abs_error=*/1.0);
 }
 
-TEST(HardwareTypeUtilsTest, Mi250XPeakComputeTFlopsPerGcd) {
+TEST(HardwareTypeUtilsTest, Mi250PeakComputeTFlopsPerGcd) {
   DeviceCapabilities device_cap;
-  // MI250X: 104 CU per GCD at 1.7 GHz, published FP16/BF16 362.1 TFLOPS per GCD.
+  // MI250: 104 CU per GCD at 1.7 GHz. Published 362.1 TFLOPS is the 208 CU
+  // package; the profiler sees one GCD.
   device_cap.set_clock_rate_in_ghz(1.7);
   device_cap.set_num_cores(104);
   device_cap.set_device_vendor("AMD");
@@ -140,7 +141,7 @@ TEST(HardwareTypeUtilsTest, Mi250XPeakComputeTFlopsPerGcd) {
 
   double peak_tflops =
       GetFlopMaxThroughputPerCore(device_cap) * device_cap.num_cores() / 1000.0;
-  EXPECT_NEAR(peak_tflops, 362.1, /*abs_error=*/1.0);
+  EXPECT_NEAR(peak_tflops, 181.0, /*abs_error=*/1.0);
 }
 
 TEST(HardwareTypeUtilsTest, Mi355XPeakComputeTFlops) {
@@ -157,7 +158,7 @@ TEST(HardwareTypeUtilsTest, Mi355XPeakComputeTFlops) {
 }
 
 TEST(HardwareTypeUtilsTest, AmbiguousAmdComputeCapabilityReportsNoPeak) {
-  // (9, 0) is gfx908 or gfx90a, whose rates differ by 2x. Without a device name
+  // (9, 0) is gfx908 or gfx90a, whose rate tables differ. Without a device name
   // to disambiguate, report nothing rather than pick one.
   DeviceCapabilities device_cap;
   device_cap.set_clock_rate_in_ghz(1.7);

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -262,10 +262,23 @@ TEST(HardwareTypeUtilsTest, GpuModelNameReportsAmdArchAndStripsFeatures) {
   EXPECT_EQ(ParseHardwareType(GpuModelName(device_cap)), HardwareType::GPU);
 }
 
+TEST(HardwareTypeUtilsTest, GpuModelNameResolvesAmdArchFromComputeCapability) {
+  DeviceCapabilities device_cap;
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+  device_cap.mutable_compute_capability()->set_minor(4);
+
+  // The pair identifies gfx942 alone, and is what the roofline tables key on.
+  EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx942");
+}
+
 TEST(HardwareTypeUtilsTest, GpuModelNameFallsBackToAmdFamilyWithoutName) {
   DeviceCapabilities device_cap;
   device_cap.set_device_vendor("AMD");
   device_cap.mutable_compute_capability()->set_major(9);
+  // (9, 0) is ambiguous between gfx908 and gfx90a, so the family is as precise
+  // as this can get.
+  device_cap.mutable_compute_capability()->set_minor(0);
 
   EXPECT_EQ(GpuModelName(device_cap), "AMD GPU - gfx-9XX series");
 }

--- a/xprof/utils/hardware_type_utils_test.cc
+++ b/xprof/utils/hardware_type_utils_test.cc
@@ -101,6 +101,65 @@ TEST(HardwareTypeUtilsTest, A100PeakComputTFlops) {
   EXPECT_NEAR(peak_tflops, 312, /*abs_error=*/1.0);
 }
 
+TEST(HardwareTypeUtilsTest, Mi300XSharedMemoryBandwidth) {
+  DeviceCapabilities device_cap;
+  // MI300X: 304 CU at 2.1 GHz, CDNA 3 (32 LDS banks x 4 B = 128 B/clock/CU).
+  device_cap.set_clock_rate_in_ghz(2.1);
+  device_cap.set_num_cores(304);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx942");
+
+  double aggregate_giga_bytes_per_second =
+      device_cap.num_cores() *
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+  // 304 * 128 B * 2.1e9 = 81,715.2 GB/s. Notably half of what the Nvidia bank
+  // model would report, since CDNA has the same 32 banks at half the width.
+  EXPECT_NEAR(aggregate_giga_bytes_per_second, 81715.2, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, Mi355XSharedMemoryBandwidthDoubles) {
+  DeviceCapabilities device_cap;
+  // MI355X: 256 CU at 2.4 GHz, CDNA 4 (64 LDS banks x 4 B = 256 B/clock/CU).
+  device_cap.set_clock_rate_in_ghz(2.4);
+  device_cap.set_num_cores(256);
+  device_cap.set_device_vendor("AMD");
+  device_cap.set_device_name("gfx950");
+
+  double aggregate_giga_bytes_per_second =
+      device_cap.num_cores() *
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+  EXPECT_NEAR(aggregate_giga_bytes_per_second, 157286.4, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, SharedMemoryBandwidthFromComputeCapability) {
+  // Traces captured before the collector emitted a device name still resolve,
+  // because (9, 4) identifies CDNA 3 unambiguously.
+  DeviceCapabilities device_cap;
+  device_cap.set_clock_rate_in_ghz(2.1);
+  device_cap.set_num_cores(304);
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+  device_cap.mutable_compute_capability()->set_minor(4);
+
+  double aggregate_giga_bytes_per_second =
+      device_cap.num_cores() *
+      tsl::profiler::UniToGiga(GetSharedMemoryBandwidthPerSM(device_cap));
+  EXPECT_NEAR(aggregate_giga_bytes_per_second, 81715.2, /*abs_error=*/1.0);
+}
+
+TEST(HardwareTypeUtilsTest, SharedMemoryBandwidthUnknownAmdArchReportsNothing) {
+  // (9, 0) is gfx908 or gfx90a, whose rates differ. Report nothing rather than
+  // pick one.
+  DeviceCapabilities device_cap;
+  device_cap.set_clock_rate_in_ghz(1.7);
+  device_cap.set_num_cores(104);
+  device_cap.set_device_vendor("AMD");
+  device_cap.mutable_compute_capability()->set_major(9);
+  device_cap.mutable_compute_capability()->set_minor(0);
+
+  EXPECT_EQ(GetSharedMemoryBandwidthPerSM(device_cap), 0.0);
+}
+
 TEST(HardwareTypeUtilsTest, GpuModelNameIgnoresNvidiaProductName) {
   DeviceCapabilities device_cap;
   device_cap.set_device_vendor("Nvidia");

--- a/xprof/utils/rocm_type_utils.cc
+++ b/xprof/utils/rocm_type_utils.cc
@@ -41,8 +41,8 @@ struct GpuFlopCapabilities {
     double bf16_tflops = 0;
     double fp16_tflops = 0;
     double fp8_tflops = 0;
-    double fp6_tflops = 0;
-    double fp4_tflops = 0;
+    double mxfp6_tflops = 0;
+    double mxfp4_tflops = 0;
     double int8_tops = 0;
 
     void ScaleWith(double scale) {
@@ -52,8 +52,8 @@ struct GpuFlopCapabilities {
       bf16_tflops *= scale;
       fp16_tflops *= scale;
       fp8_tflops *= scale;
-      fp6_tflops *= scale;
-      fp4_tflops *= scale;
+      mxfp6_tflops *= scale;
+      mxfp4_tflops *= scale;
       int8_tops *= scale;
     }
   };
@@ -170,8 +170,8 @@ std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
                             .bf16_tflops = 4096,
                             .fp16_tflops = 4096,
                             .fp8_tflops = 8192,
-                            .fp6_tflops = 16384,
-                            .fp4_tflops = 16384,
+                            .mxfp6_tflops = 16384,
+                            .mxfp4_tflops = 16384,
                             .int8_tops = 8192}}},
       };
   auto it = kTable.find(gfx_version);

--- a/xprof/utils/rocm_type_utils.cc
+++ b/xprof/utils/rocm_type_utils.cc
@@ -95,6 +95,11 @@ absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
 // AMD CDNA 4 architecture whitepaper, which additionally covers the LDS spec 
 // for earlier generations (CDNA 3 and prior):
 // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+// 
+// "The LDS in the AMD CDNA 3 architecture and prior 
+// generations was a directly addressed structure with 32 banks, each containing 512 entries for 32-bits of 
+// data – a total of 64KB of data. Each bank could read and write a 32-bit value and the LDS incorporates logic 
+// for conflict detection and scheduling, a sophisticated crossbar and swizzle unit along with atomic execution units."
 //
 // RDNA series is absent as its LDS belongs to a workgroup processor rather than
 // a CU. The published per-cycle figure cannot clearly be attributed per CU.

--- a/xprof/utils/rocm_type_utils.cc
+++ b/xprof/utils/rocm_type_utils.cc
@@ -37,16 +37,24 @@ struct GpuFlopCapabilities {
   struct FlopCapabilityOnPrecisions {
     double fp64_tflops = 0;
     double fp32_tflops = 0;
+    double tf32_tflops = 0;
     double bf16_tflops = 0;
     double fp16_tflops = 0;
     double fp8_tflops = 0;
+    double fp6_tflops = 0;
+    double fp4_tflops = 0;
+    double int8_tops = 0;
 
     void ScaleWith(double scale) {
       fp64_tflops *= scale;
       fp32_tflops *= scale;
+      tf32_tflops *= scale;
       bf16_tflops *= scale;
       fp16_tflops *= scale;
       fp8_tflops *= scale;
+      fp6_tflops *= scale;
+      fp4_tflops *= scale;
+      int8_tops *= scale;
     }
   };
 
@@ -118,29 +126,53 @@ std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
     absl::string_view gfx_version) {
   static const auto& kTable =
       *new absl::btree_map<absl::string_view, GpuFlopCapabilities>{
-          // MI100 (CDNA 1), FLOPS/CLOCK/CU
+          // MI100 (CDNA 1), Table 1 FLOPS/CLOCK/CU
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna-white-paper.pdf
           // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html
           {"gfx908",
            {.vector_unit = {.fp64_tflops = 64, .fp32_tflops = 128},
-            .matrix_unit = {.bf16_tflops = 512, .fp16_tflops = 1024}}},
-          // MI250X (CDNA 2), FLOPS/CLOCK/CU
+            .matrix_unit = {.fp32_tflops = 256,
+                            .bf16_tflops = 512,
+                            .fp16_tflops = 1024,
+                            .int8_tops = 1024}}},
+          // MI250X (CDNA 2), Table 1 FLOPS/CLOCK/CU.
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf
           // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html
           {"gfx90a",
            {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 128},
-            .matrix_unit = {.bf16_tflops = 1024, .fp16_tflops = 1024}}},
-          // MI300X (CDNA 3). CDNA 4 whitepaper Table 1, MI300X column.
-          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+            .matrix_unit = {.fp64_tflops = 256,
+                            .fp32_tflops = 256,
+                            .bf16_tflops = 1024,
+                            .fp16_tflops = 1024,
+                            .int8_tops = 1024}}},
+          // MI300X (CDNA 3), Table 1 FLOPS/CLOCK/CU
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf
+          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi300.html
           {"gfx942",
-           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 2048,
+           {.vector_unit = {.fp64_tflops = 128,
+                            .fp32_tflops = 256,
+                            .fp16_tflops = 256},
+            .matrix_unit = {.fp64_tflops = 256,
+                            .fp32_tflops = 256,
+                            .tf32_tflops = 1024,
+                            .bf16_tflops = 2048,
                             .fp16_tflops = 2048,
-                            .fp8_tflops = 4096}}},
-          // MI355X (CDNA 4). CDNA 4 whitepaper Table 1, MI355X column.
+                            .fp8_tflops = 4096,
+                            .int8_tops = 4096}}},
+          // MI355X (CDNA 4), Table 1 FLOPS/CLOCK/CU
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
           {"gfx950",
-           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 4096,
+           {.vector_unit = {.fp64_tflops = 128,
+                            .fp32_tflops = 256,
+                            .fp16_tflops = 256},
+            .matrix_unit = {.fp64_tflops = 128,
+                            .fp32_tflops = 256,
+                            .bf16_tflops = 4096,
                             .fp16_tflops = 4096,
-                            .fp8_tflops = 8192}}},
+                            .fp8_tflops = 8192,
+                            .fp6_tflops = 16384,
+                            .fp4_tflops = 16384,
+                            .int8_tops = 8192}}},
       };
   auto it = kTable.find(gfx_version);
   if (it == kTable.end()) return std::nullopt;

--- a/xprof/utils/rocm_type_utils.cc
+++ b/xprof/utils/rocm_type_utils.cc
@@ -1,0 +1,193 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xprof/utils/rocm_type_utils.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+
+#include "absl/container/btree_map.h"
+#include "absl/log/log.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/profiler/utils/math_utils.h"
+#include "plugin/xprof/protobuf/hardware_types.pb.h"
+
+namespace tensorflow {
+namespace profiler {
+namespace rocm {
+namespace {
+
+struct GpuFlopCapabilities {
+  struct FlopCapabilityOnPrecisions {
+    double fp64_tflops = 0;
+    double fp32_tflops = 0;
+    double bf16_tflops = 0;
+    double fp16_tflops = 0;
+    double fp8_tflops = 0;
+
+    void ScaleWith(double scale) {
+      fp64_tflops *= scale;
+      fp32_tflops *= scale;
+      bf16_tflops *= scale;
+      fp16_tflops *= scale;
+      fp8_tflops *= scale;
+    }
+  };
+
+  FlopCapabilityOnPrecisions vector_unit;
+  FlopCapabilityOnPrecisions matrix_unit;
+
+  void ScaleWith(double scale) {
+    vector_unit.ScaleWith(scale);
+    matrix_unit.ScaleWith(scale);
+  }
+};
+
+// ROCm XLA collector emits rocprofiler-sdk's agent name, composed via
+// fmt::format("gfx{}{}{:x}", major, minor, step), e.g. "gfx942". 
+// See rocprofiler-sdk source/lib/rocprofiler-sdk/agent.cpp.
+// Reject a device name that does not follow this formatting.
+absl::string_view GfxVersionIfWellFormed(absl::string_view device_name) {
+  if (!absl::StartsWith(device_name, "gfx")) return "";
+  absl::string_view suffix = device_name.substr(3);
+  if (suffix.size() < 3) return "";
+  for (char c : suffix) {
+    if (!absl::ascii_isxdigit(c)) return "";
+  }
+  return device_name;
+}
+
+// Fallback for traces captured before the collector reported a device name.
+// Resolves only when the major, minor pair can identify a unique architecture.
+absl::string_view GfxVersionFromComputeCapability(int major, int minor) {
+  if (major == 9 && minor == 4) return "gfx942";  // CDNA 3, MI300 series
+  if (major == 9 && minor == 5) return "gfx950";  // CDNA 4, MI350 series
+  return "";
+}
+
+absl::string_view ResolveAmdGfxVersion(const DeviceCapabilities& device_cap) {
+  absl::string_view gfx = GfxVersionIfWellFormed(device_cap.device_name());
+  if (!gfx.empty()) return gfx;
+  return GfxVersionFromComputeCapability(
+      device_cap.compute_capability().major(),
+      device_cap.compute_capability().minor());
+}
+
+// LDS bytes per CU per clock.
+// Each bank serves one read, write or atomic per cycle.
+//
+// AMD CDNA 4 architecture whitepaper, which additionally covers the LDS spec 
+// for earlier generations (CDNA 3 and prior):
+// https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+//
+// RDNA series is absent as its LDS belongs to a workgroup processor rather than
+// a CU. The published per-cycle figure cannot clearly be attributed per CU.
+double GetAmdLdsBytesPerCuPerCycle(absl::string_view gfx_version) {
+  static const auto& kTable = *new absl::btree_map<absl::string_view, double>{
+      {"gfx908", 128.0},  // CDNA 1, 32 banks x 4 B
+      {"gfx90a", 128.0},  // CDNA 2, 32 banks x 4 B
+      {"gfx942", 128.0},  // CDNA 3, 32 banks x 4 B
+      {"gfx950", 256.0},  // CDNA 4, 64 banks x 4 B
+  };
+  auto it = kTable.find(gfx_version);
+  return it == kTable.end() ? 0.0 : it->second;
+}
+
+// FMA considered as 2 FLOPs.
+// Matrix rates are dense MFMA, vector rates are VALU.
+std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
+    absl::string_view gfx_version) {
+  static const auto& kTable =
+      *new absl::btree_map<absl::string_view, GpuFlopCapabilities>{
+          // MI100 (CDNA 1), 120 CU at 1.502 GHz: FP64 11.5, FP32 23.1,
+          // BF16 92.3, FP16 184.6 TFLOPS. bf16 MFMA is half rate on CDNA 1.
+          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html
+          {"gfx908",
+           {.vector_unit = {.fp64_tflops = 64, .fp32_tflops = 128},
+            .matrix_unit = {.bf16_tflops = 512, .fp16_tflops = 1024}}},
+          // MI250X (CDNA 2), 104 CU per GCD at 1.7 GHz: FP64 45.3, FP32 45.3,
+          // FP16 = BF16 362.1 TFLOPS per GCD. Full-rate FP64.
+          // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html
+          {"gfx90a",
+           {.vector_unit = {.fp64_tflops = 256, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 2048, .fp16_tflops = 2048}}},
+          // MI300X (CDNA 3). CDNA 4 whitepaper Table 1, MI300X column.
+          // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
+          {"gfx942",
+           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 2048,
+                            .fp16_tflops = 2048,
+                            .fp8_tflops = 4096}}},
+          // MI355X (CDNA 4). CDNA 4 whitepaper Table 1, MI355X column.
+          {"gfx950",
+           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 256},
+            .matrix_unit = {.bf16_tflops = 4096,
+                            .fp16_tflops = 4096,
+                            .fp8_tflops = 8192}}},
+      };
+  auto it = kTable.find(gfx_version);
+  if (it == kTable.end()) return std::nullopt;
+  return it->second;
+}
+
+}  // namespace
+
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap) {
+  absl::string_view gfx_version = ResolveAmdGfxVersion(device_cap);
+  std::optional<GpuFlopCapabilities> cu_flops =
+      GetAmdFlopCapsPerCuPerCycle(gfx_version);
+  if (!cu_flops.has_value()) {
+    LOG(WARNING) << "No FLOP rates known for AMD architecture '" << gfx_version
+                 << "'; peak compute will be reported as zero.";
+    return 0.0;
+  }
+  cu_flops->ScaleWith(device_cap.clock_rate_in_ghz());
+  return std::max(
+      {cu_flops->vector_unit.fp32_tflops, cu_flops->vector_unit.fp16_tflops,
+       cu_flops->matrix_unit.fp32_tflops, cu_flops->matrix_unit.fp16_tflops});
+}
+
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap) {
+  double bytes_per_cycle =
+      GetAmdLdsBytesPerCuPerCycle(ResolveAmdGfxVersion(device_cap));
+  if (bytes_per_cycle <= 0.0) return 0.0;
+  return tsl::profiler::GigaToUni(bytes_per_cycle *
+                                  device_cap.clock_rate_in_ghz());
+}
+
+std::string GpuModelName(const DeviceCapabilities& device_cap) {
+  // Attempt to resolve exact gfx architecture. If no resolution
+  // is reached, fall back to displaying the family (major) name.
+  absl::string_view gfx = ResolveAmdGfxVersion(device_cap);
+  if (!gfx.empty()) return absl::StrCat("AMD GPU - ", gfx);
+  switch (device_cap.compute_capability().major()) {
+    case 9:
+      return "AMD GPU - gfx-9XX series";
+    case 10:
+      return "AMD GPU - gfx-10XX series";
+    case 11:
+      return "AMD GPU - gfx-11XX series";
+    default:
+      return "AMD GPU";
+  }
+}
+
+}  // namespace rocm
+}  // namespace profiler
+}  // namespace tensorflow

--- a/xprof/utils/rocm_type_utils.cc
+++ b/xprof/utils/rocm_type_utils.cc
@@ -114,24 +114,20 @@ double GetAmdLdsBytesPerCuPerCycle(absl::string_view gfx_version) {
   return it == kTable.end() ? 0.0 : it->second;
 }
 
-// FMA considered as 2 FLOPs.
-// Matrix rates are dense MFMA, vector rates are VALU.
 std::optional<GpuFlopCapabilities> GetAmdFlopCapsPerCuPerCycle(
     absl::string_view gfx_version) {
   static const auto& kTable =
       *new absl::btree_map<absl::string_view, GpuFlopCapabilities>{
-          // MI100 (CDNA 1), 120 CU at 1.502 GHz: FP64 11.5, FP32 23.1,
-          // BF16 92.3, FP16 184.6 TFLOPS. bf16 MFMA is half rate on CDNA 1.
+          // MI100 (CDNA 1), FLOPS/CLOCK/CU
           // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html
           {"gfx908",
            {.vector_unit = {.fp64_tflops = 64, .fp32_tflops = 128},
             .matrix_unit = {.bf16_tflops = 512, .fp16_tflops = 1024}}},
-          // MI250X (CDNA 2), 104 CU per GCD at 1.7 GHz: FP64 45.3, FP32 45.3,
-          // FP16 = BF16 362.1 TFLOPS per GCD. Full-rate FP64.
+          // MI250X (CDNA 2), FLOPS/CLOCK/CU
           // https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html
           {"gfx90a",
-           {.vector_unit = {.fp64_tflops = 256, .fp32_tflops = 256},
-            .matrix_unit = {.bf16_tflops = 2048, .fp16_tflops = 2048}}},
+           {.vector_unit = {.fp64_tflops = 128, .fp32_tflops = 128},
+            .matrix_unit = {.bf16_tflops = 1024, .fp16_tflops = 1024}}},
           // MI300X (CDNA 3). CDNA 4 whitepaper Table 1, MI300X column.
           // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf
           {"gfx942",

--- a/xprof/utils/rocm_type_utils.h
+++ b/xprof/utils/rocm_type_utils.h
@@ -1,0 +1,41 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XPROF_UTILS_ROCM_TYPE_UTILS_H_
+#define XPROF_UTILS_ROCM_TYPE_UTILS_H_
+
+#include <string>
+
+#include "plugin/xprof/protobuf/hardware_types.pb.h"
+
+namespace tensorflow {
+namespace profiler {
+namespace rocm {
+
+// Peak throughput in GFLOPs per second per CU, at the reported clock.
+double GetFlopMaxThroughputPerCore(const DeviceCapabilities& device_cap);
+
+// LDS bandwidth in Bytes per second per CU. LDS is the AMD analogue of Nvidia
+// shared memory.
+double GetSharedMemoryBandwidthPerCore(const DeviceCapabilities& device_cap);
+
+// GCN architecture, e.g. "AMD GPU - gfx942".
+std::string GpuModelName(const DeviceCapabilities& device_cap);
+
+}  // namespace rocm
+}  // namespace profiler
+}  // namespace tensorflow
+
+#endif  // XPROF_UTILS_ROCM_TYPE_UTILS_H_


### PR DESCRIPTION
Improvements to the Roofline Analysis tool for AMD GPUs.

---

## Summary of changes

- Add `DeviceCapabilities.device_name`, populated from the existing `kGpuDeviceName` stat in the XPlane. For the ROCm GPU path, this is populated from the XLA profiler backend at `rocm_collector.cc`, which emits the GCN architecture eg. "gfx942".
  - <https://github.com/openxla/xla/pull/47067> (merged)
  - Format of agent name (which supplies `kGpuDeviceName` in collector): <https://github.com/ROCm/rocprofiler-sdk/blob/amd-staging/source/lib/rocprofiler-sdk/agent.cpp#L769-L775>

- Split the vendor hardware models (lookup tables for peak FLOPs capabilities and shared mem/LDS bandwidth) into `cuda_type_utils.cc` and `rocm_type_utils.cc`. 
  - `hardware_type_utils.cc` keeps the public signatures and dispatches on `device_vendor`. Future vendors can follow this pattern and add to this call site.
  - Both namespaces expose the same (three) `PerCore` signatures, so the vendors are interchangeable at the call site.

- Implement AMD models for LDS memory structure, LDS bandwidth and FLOPs capabilities per CU. Lookup tables added to `rocm_type_utils.cc`, mirroring the existing NVIDIA models now in `cuda_type_utils.cc`. Constructed using the datasheet sources below.
  - These tables are keyed on the gfx architecture provided by `kGpuDeviceName`, with a fallback implementation keying on the existing major, minor fields.

- Rename the functions that dispatch on vendor: `GetFlopMaxThroughputPerSM`, `GetSharedMemoryBandwidthPerSM` and `GetGpuFlopCapabilitiesPerSM` become `...PerCore`.
  - Reasoning/rationale for this explained in comments below. Basically, there is existing precedence for "core" to refer to an SM or CU.
  - NVIDIA-only tables and lookups keep `PerSM`, AMD-only ones `PerCu`.
  - The FLOP capability fields are left alone: `cuda_core`/`tensor_core` stay with the NVIDIA tables, and the AMD struct uses `vector_unit`/`matrix_unit`.

- `GetSharedMemoryBandwidthPerCore` now gates on vendor (`kDeviceVendorNvidia`, `kDeviceVendorAmd`). Return 0 for unimplemented vendors (as oppose to unilaterally applying the NVIDIA bandwidth model).

- Roofline metrics `kDevCapPeakTeraflopsPerSecond`, `kDevCapPeakSram{Rd,Wr}BwGigabytesPerSecond` in `xplane_to_op_stats.cc` will now prefer the existing XPlane stat if present and positive (i.e. if XLA profiler backend collector has intentionally produced these fields)
  - If the given stat is not present, it will fall back to the derived lookup table method added here.
  - Such that. if in future, ROCm side (or CUDA) decide to shift responsibility to the XLA profiler collector to produce these fields (of which the majority already are), then XProf will accept these in light of being a more intentional, first-class value.

- `GpuModelName` now returns `std::string` rather than `absl::string_view`, as the AMD path can return a `StrCat` rather than a literal.

- New unit tests in `hardware_type_utils_test.cc` to verify AMD path.

- New unit tests in `xplane_to_op_stats_test.cc` to verify XPlane stat preference and lookup table derivation fallback.

---

## Consequences

- Existing traces whose XPlane have no supplied `kGpuDeviceName` will enter the fallback, which resolves the architecture from the compute capability (major, minor fields), which ROCm derives from `gfx_target_version` with the step digit dropped.
  - MI300 series `(9, 4)` and MI350 series `(9, 5)` each identify a unique architecture and get the compute ceiling and the LDS band with no recapture and no XLA collector-side change.
  - `(9, 0)` is ambiguous between gfx908 (MI100) and gfx90a (MI250), whose rates differ, so the roofline metrics will resolve to 0, and the shared-mem/L1 band omitted, rather than rendering an inaccurate NVIDIA-derived figure. These traces will require a recapture carrying the `kGpuDeviceName` field (from openxla/xla#47067) to observe the updated roofline metrics.
  - The rendered device name follows the same resolution, so `(9, 4)` and `(9, 5)` render as `AMD GPU - gfx942` and `AMD GPU - gfx950`, while the ambiguous `(9, 0)` keeps the family string `AMD GPU - gfx-9XX series`.
 
- ROCm traces with an occupied `kGpuDeviceName` stat in the XPlane will render the new updated roofline metrics.

- **CUDA trace behaviour is unchanged.**
  - CUDA XLA profiler collector does not emit any of the `kDevCapPeak...` stats so the new preference for existing XPlane stats will not be triggered. HOWEVER if the CUDA collector decides to produce this stat in future, it will prefer this XLA provided value. As mentioned already this would be an intentional decision to fill from XLA and preferring this value should ideally be desired behaviour, but should be noted regardless.
  - The vendor gate leaves the NVIDIA branch of `GetSharedMemoryBandwidthPerCore` identical to its prior implementation, `GetSharedMemoryBandwidthPerSM`.
  - `GpuModelName` still returns the microarchitecture family rather than the CUPTI product name, preserving the `GPU` substring that `ParseHardwareType`, the roofline table selection and the frontend all key on. Covered by a regression test.

---

## Evidence

### AMD
XProf 2.23.1 (BEFORE CHANGES) 8x MI300X (gfx942) profiled via JAX
<img width="1885" height="907" alt="image" src="https://github.com/user-attachments/assets/ea60d710-ac42-4518-9a0b-8cfcd512ffb5" />


(AFTER PR CHANGES) 8x MI300X (gfx942) profiled via JAX
<img width="1886" height="902" alt="image" src="https://github.com/user-attachments/assets/65c50de4-8159-4b04-9b7f-a8e979055e31" />


### NVIDIA
XProf 2.23.1 (BEFORE CHANGES) 4x H100 profiled via JAX
<img width="1880" height="904" alt="image" src="https://github.com/user-attachments/assets/5bd0c03d-7d82-460f-9126-7bc2eaf1ec72" />


(AFTER PR CHANGES) 4x H100 profiled via JAX (UNCHANGED)
<img width="1878" height="901" alt="image" src="https://github.com/user-attachments/assets/876f17ca-dd43-4ae7-88bd-de6cade31643" />

---

## Sources for CU specs
- [CDNA 1 architecture whitepaper](https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna-white-paper.pdf)
- [CDNA 2 architecture whitepaper](https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf)
- [CDNA 3 architecture whitepaper](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf)
- [CDNA 4 architecture whitepaper](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf)
- [MI100 architecture doc](https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi100.html)
- [MI250 architecture doc](https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi250.html)
- [MI300 architecture doc](https://rocm.docs.amd.com/en/latest/reference/gpu-arch/mi300.html)

---
