### PR TITLE
Fix segfault: pass empty C string, not NULL, for absent char* args in _pywrap_profiler_plugin

### DIFF
--- a/xprof/pywrap/_pywrap_profiler_plugin.py
+++ b/xprof/pywrap/_pywrap_profiler_plugin.py
@@ -221,9 +221,13 @@ def trace(
   """
   packed = _pack_options(options)
   err = _lib.Trace(
-      service_addr.encode() if service_addr else None,
-      logdir.encode() if logdir else None,
-      worker_list.encode() if worker_list else None,
+      # Marshal absent values to an empty C string, not NULL: the C side
+      # strlen()s these, so a None (-> NULL char*) segfaults. worker_list is
+      # empty by default for a single-host capture, which is how the "Capture
+      # Profile" UI reaches this call.
+      (service_addr or "").encode(),
+      (logdir or "").encode(),
+      (worker_list or "").encode(),
       include_dataset_ops,
       duration_ms,
       num_tracing_attempts,
@@ -268,7 +272,7 @@ def monitor(
   """
   content_ptr = ctypes.c_void_p()
   err = _lib.Monitor(
-      service_addr.encode() if service_addr else None,
+      (service_addr or "").encode(),
       duration_ms,
       monitoring_level,
       display_timestamp,
@@ -307,7 +311,7 @@ def start_continuous_profiling(
   """
   packed = _pack_options(options)
   err = _lib.StartContinuousProfiling(
-      service_addr.encode() if service_addr else None,
+      (service_addr or "").encode(),
       packed.keys,
       packed.string_vals,
       packed.int_vals,
@@ -326,7 +330,7 @@ _lib.StopContinuousProfiling.restype = ctypes.c_void_p
 
 def stop_continuous_profiling(service_addr: str) -> None:
   err = _lib.StopContinuousProfiling(
-      service_addr.encode() if service_addr else None
+      (service_addr or "").encode()
   )
   _check_error(err)
 
@@ -337,8 +341,8 @@ _lib.GetSnapshot.restype = ctypes.c_void_p
 
 def get_snapshot(service_addr: str, logdir: str) -> None:
   err = _lib.GetSnapshot(
-      service_addr.encode() if service_addr else None,
-      logdir.encode() if logdir else None,
+      (service_addr or "").encode(),
+      (logdir or "").encode(),
   )
   _check_error(err)
 
@@ -391,7 +395,7 @@ def xspace_to_tools_data(
   err = _lib.XSpaceToToolsData(
       c_paths,
       len(xspace_paths),
-      tool_name.encode() if tool_name else None,
+      (tool_name or "").encode(),
       packed.keys,
       packed.string_vals,
       packed.int_vals,
@@ -478,7 +482,7 @@ def xspace_to_tools_data_from_byte_string(
       c_sizes,
       c_paths,
       num_xspaces,
-      tool_name.encode() if tool_name else None,
+      (tool_name or "").encode(),
       packed.keys,
       packed.string_vals,
       packed.int_vals,
@@ -516,7 +520,7 @@ _lib.InitializeStubs.restype = None
 
 def initialize_stubs(worker_service_addresses: str) -> None:
   _lib.InitializeStubs(
-      worker_service_addresses.encode() if worker_service_addresses else None
+      (worker_service_addresses or "").encode()
   )
 
 _lib.BuiltWithEmbedded.argtypes = []


### PR DESCRIPTION
## What

`trace()` in `xprof/pywrap/_pywrap_profiler_plugin.py` marshals its string arguments with
`x.encode() if x else None`. An empty (or `None`) value therefore becomes a **NULL `char*`**.
`_lib.Trace.argtypes` declares them as `ctypes.c_char_p`, and the C `Trace` implementation
`strlen()`s these pointers, so a NULL dereferences and the process dies with **SIGSEGV**.

`worker_list` is empty by default for a single-host capture — which is exactly how the
**"Capture Profile"** UI reaches this function (`profile_plugin.py` `capture_route_impl` passes
the request's `worker_list`, empty when the user doesn't list workers). So on affected platforms,
every UI capture without an explicit worker list crashes the xprof process.

This regressed with the ctypes remote-capture path (2.22+); the older pybind11 build did not
crash.

## Reproduction (no JAX/TF, no server needed)

```python
from xprof.convert import _pywrap_profiler_plugin as p
# (service_addr, logdir, worker_list, include_dataset_ops, duration_ms, num_tracing_attempts, options)
p.trace("localhost:59999", "/tmp/out", "", True, 1000, 1, {})
```

```console
$ python repro.py ; echo $?
139        # SIGSEGV — crashes even though nothing is listening on the port
```

lldb: `EXC_BAD_ACCESS (code=1, address=0x0)` in `libsystem_platform.dylib`_platform_strlen` —
`strlen(NULL)`.

Varying only `worker_list` isolates it:

| `worker_list`            | result                                                              |
| ------------------------ | ------------------------------------------------------------------- |
| `""` (empty — UI default)| **SIGSEGV**                                                         |
| `None`                   | **SIGSEGV**                                                         |
| `"x"` (any non-empty)    | no crash — graceful `RuntimeError: INVALID_ARGUMENT: Could not interpret "x" as a host-port pair.` |

A non-NULL pointer is handled cleanly; a NULL one crashes.

## Fix

Marshal absent values to an empty C string rather than NULL:

```python
(service_addr or "").encode(),
(logdir or "").encode(),
(worker_list or "").encode(),
```

## Testing

Applied the change to an installed `xprof==2.23.1` and re-ran on macOS 26.5.1 (arm64),
Python 3.12:

- **Before:** `trace(..., worker_list="", ...)` → SIGSEGV (exit 139).
- **After, no server (dead port):** clean `RuntimeError: UNAVAILABLE: No trace event was
  collected …` — no crash.
- **After, live `jax.profiler.start_server(9031)`:** capture succeeds and writes
  `plugins/profile/<ts>/localhost_9031.xplane.pb`.

## Scope

The same `x.encode() if x else None` idiom appears throughout this file, all with the same latent
NULL-deref risk. The identical fix is applied to every affected call: `trace`, `monitor`,
`start_continuous_profiling`, `stop_continuous_profiling`, `get_snapshot`, `xspace_to_tools_data`,
`xspace_to_tools_data_from_byte_string`, and `initialize_stubs`.

## Reproducing the other paths

Each of these segfaults on an empty string arg too (same root cause). Verified on macOS arm64,
`xprof==2.23.1`: every call below exits **139 (SIGSEGV)** unpatched, and is crash-free after the fix:

```python
from xprof.convert import _pywrap_profiler_plugin as p
p.monitor("", 100, 1, False)                                         # service_addr
p.start_continuous_profiling("")                                     # service_addr
p.stop_continuous_profiling("")                                      # service_addr
p.get_snapshot("", "/tmp/snap")                                      # service_addr
p.xspace_to_tools_data(["/tmp/x.pb"], "")                            # tool_name
p.xspace_to_tools_data_from_byte_string([b"x"], ["/tmp/x.pb"], "")   # tool_name
p.initialize_stubs("")                                               # worker_service_addresses
```

After the fix the four address-taking calls raise a clean
`RuntimeError: INVALID_ARGUMENT: Could not interpret "" as a host-port pair.`; the rest return
without crashing.
